### PR TITLE
correctly show settings for 'dreiviertel'

### DIFF
--- a/webpage/script.js
+++ b/webpage/script.js
@@ -345,9 +345,7 @@ function initWebsocket() {
 			$("#boot-show-wifi").set("checked", data.bootShowWifi | 0);
 			$("#boot-show-ip").set("checked", data.bootShowIP | 0);
 
-			enableSpecific("specific-layout-2", data.UhrtypeDef === 2);
-			enableSpecific("specific-layout-2", data.UhrtypeDef === 6);
-			enableSpecific("specific-layout-2", data.UhrtypeDef === 7);
+			enableSpecific("specific-layout-2", data.UhrtypeDef === 2 || data.UhrtypeDef === 6 || data.UhrtypeDef === 7);
 			enableSpecific("specific-layout-4", data.UhrtypeDef === 4);
 			enableSpecific("specific-layout-5", data.UhrtypeDef === 5);
 			enableSpecific("specific-colortype-4", data.colortype === 4);


### PR DESCRIPTION
Commit 7c234a2 introduced a bug, that it only showed this setting for
the new layout, instead of for old and new layouts.