### PR TITLE
Automatically generate version from `package.json`

### DIFF
--- a/extra_scripts.py
+++ b/extra_scripts.py
@@ -1,5 +1,30 @@
 Import("env")
 
+package_json = env.File("package.json")
+
+#
+# automatically generate `include/version.h`
+#
+def build_version_h(target, source, env):
+    import json
+
+    version = None
+    with open(str(source[0]), "r") as f:
+        version = json.load(f)["version"]
+
+    with open(str(target[0]), "w") as h:
+        h.write('// Automatically generated -- do not modify\n')
+        h.write('// Modify `package.json` instead.\n\n')
+        h.write('#define VERSION "' + version + '"\n')
+
+    return None
+
+env.Command(
+    target="include/version.gen.h",
+    source=package_json,
+    action=build_version_h
+)
+
 #
 # automatically build web page
 #
@@ -16,4 +41,5 @@ grunt_build = env.Command(
     action="npx --no-install grunt build"
 )
 env.Depends(grunt_build, npm_ci)
-env.Depends(grunt_build, Glob("webpage/*"))
+env.Depends(grunt_build, package_json)
+env.Depends(grunt_build, env.Glob("webpage/*"))

--- a/include/.gitignore
+++ b/include/.gitignore
@@ -1,2 +1,2 @@
 # generated file:
-WebPageContent.gen.inc
+*.gen.*

--- a/include/EEPROMAnything.h
+++ b/include/EEPROMAnything.h
@@ -30,8 +30,7 @@ void eeprom_write() {
 void eeprom_read() {
     EEPROM_readAnything(0, G);
 
-    Serial.print("Version   : ");
-    Serial.println(VER);
+    Serial.printf("Version   : %s\n", VERSION);
     Serial.printf("Sernr     : %u\n", G.sernr);
     Serial.printf("Programm  : %u\n", G.prog);
     Serial.printf("Conf      : %u\n", G.conf);

--- a/include/Uhr.h
+++ b/include/Uhr.h
@@ -1,7 +1,6 @@
 #pragma once
 #include "Arduino.h"
-
-const char *VER = "2.6.0"; // Software Version
+#include "version.gen.h"
 
 #define MAX_ARRAY_SIZE 291
 

--- a/src/Wortuhr.ino
+++ b/src/Wortuhr.ino
@@ -430,7 +430,7 @@ void setup() {
     //-------------------------------------
     Serial.println("--------------------------------------");
     Serial.println("ESP Uhr");
-    Serial.print("Version         : "), Serial.println(VER);
+    Serial.printf("Version         : %s\n", VERSION);
     Serial.printf("Chip ID         : %08X\n", ESP.getChipId());
     Serial.printf("Flash ID        : %08X\n\n", ESP.getFlashChipId());
     Serial.printf("CPU Speed       : %u MHz \n\n", ESP.getCpuFreqMHz());


### PR DESCRIPTION
Consolidate definition of version number for both the Webpages and the
console output to the 'version' property of `package.json`. 

Fixes #107.