### PR TITLE
Rework of frontMatrix functions and uhrtype minArray handling

### DIFF
--- a/include/Uhr.h
+++ b/include/Uhr.h
@@ -113,8 +113,8 @@ uint8_t _hour = 0;
 uint8_t lastSecond = 0;
 uint8_t lastMinute = 0;
 
-uint16_t frontMatrix[MAX_ARRAY_SIZE] = {0};
-uint16_t lastFrontMatrix[MAX_ARRAY_SIZE] = {0};
+bool frontMatrix[MAX_ARRAY_SIZE] = {false};
+bool lastFrontMatrix[MAX_ARRAY_SIZE] = {false};
 bool parametersChanged = false;
 uint8_t statusAccessPoint = 0;
 

--- a/include/Uhrtypes/Uhrtype.hpp
+++ b/include/Uhrtypes/Uhrtype.hpp
@@ -127,5 +127,7 @@ public:
         return returnValue;
     };
 
-    virtual const uint16_t getMinArr(uint8_t col, uint8_t row) = 0;
+    virtual const uint16_t getMinArr(uint8_t col, uint8_t row) {
+        return NUM_PIXELS() - (4 - row);
+    };
 };

--- a/include/Uhrtypes/Uhrtype.hpp
+++ b/include/Uhrtypes/Uhrtype.hpp
@@ -86,9 +86,7 @@ enum ledText {
 
 class iUhrType {
 public:
-    virtual void Letter_set(const uint16_t index) {
-        frontMatrix[index] = index;
-    }
+    virtual void Letter_set(const uint16_t index) { frontMatrix[index] = true; }
 
     virtual void show(uint8_t text) = 0;
 

--- a/include/Uhrtypes/uhr_func_114_2Clock.hpp
+++ b/include/Uhrtypes/uhr_func_114_2Clock.hpp
@@ -18,16 +18,6 @@
 
 class UHR_114_2Clock_t : public iUhrType {
 public:
-    const uint16_t min_arr[2][4] = {{110, 111, 112, 113}, {110, 111, 112, 113}};
-
-    //------------------------------------------------------------------------------
-
-    virtual const uint16_t getMinArr(uint8_t col, uint8_t row) override {
-        return min_arr[col][row];
-    };
-
-    //------------------------------------------------------------------------------
-
     virtual const bool hasDreiviertel() override { return true; }
 
     //------------------------------------------------------------------------------

--- a/include/Uhrtypes/uhr_func_114_Alternative.hpp
+++ b/include/Uhrtypes/uhr_func_114_Alternative.hpp
@@ -20,20 +20,6 @@
 
 class UHR_114_Alternative_t : public iUhrType {
 public:
-    const uint16_t min_arr[2][4] = {
-        // ergänzt aus "Uhr func 169"-datei
-        {110, 111, 112, 113}, // LED für Minuten Anzeige Zeile
-        {110, 111, 112, 113}  // LED für Minuten Anzeige Ecken
-    };
-
-    //------------------------------------------------------------------------------
-
-    virtual const uint16_t getMinArr(uint8_t col, uint8_t row) override {
-        return min_arr[col][row];
-    };
-
-    //------------------------------------------------------------------------------
-
     virtual const bool hasDreiviertel() override { return true; }
 
     //------------------------------------------------------------------------------

--- a/include/Uhrtypes/uhr_func_114_dutch.hpp
+++ b/include/Uhrtypes/uhr_func_114_dutch.hpp
@@ -18,20 +18,6 @@
 
 class UHR_114_dutch_t : public iUhrType {
 public:
-    const uint16_t min_arr[2][4] = {
-        // ergänzt aus "Uhr func 169"-datei
-        {110, 111, 112, 113}, // LED für Minuten Anzeige Zeile
-        {110, 111, 112, 113}  // LED für Minuten Anzeige Ecken
-    };
-
-    //------------------------------------------------------------------------------
-
-    virtual const uint16_t getMinArr(uint8_t col, uint8_t row) override {
-        return min_arr[col][row];
-    };
-
-    //------------------------------------------------------------------------------
-
     virtual const bool hasZwanzig() override { return false; }
 
     //------------------------------------------------------------------------------

--- a/include/Uhrtypes/uhr_func_125.hpp
+++ b/include/Uhrtypes/uhr_func_125.hpp
@@ -1,9 +1,25 @@
 #include "Uhrtype.hpp"
 
+/*
+ * Layout Front
+ *
+ * E S K I S T A F Ü N F
+ * Z E H N D A U V O R G
+ * N A C H V I E R T E L
+ * H A L B V O R N A C H
+ * E I N S K U R Z W E I
+ * D R E I A U J V I E R
+ * F Ü N F T O S E C H S
+ * S I E B E N L A C H T
+ * A N E U N M H Z E H N
+ * Z W Ö L F D T F E L F
+ * W A S D F U N K U H R
+ * + + + +
+ */
+
 class UHR_125_t : public iUhrType {
 public:
     const uint16_t min_arr[2][4] = {
-        // ergänzt aus "Uhr func 169"-datei
         {110, 111, 112, 113}, // LED für Minuten Anzeige Zeile
         {121, 122, 123, 124}  // LED für Minuten Anzeige Ecken
     };

--- a/include/Uhrtypes/uhr_func_125_Type2.hpp
+++ b/include/Uhrtypes/uhr_func_125_Type2.hpp
@@ -1,38 +1,24 @@
 #include "Uhrtype.hpp"
 
+/*
+ * Layout Front
+ *
+ * E S K I S T A F Ü N F
+ * Z E H N D A U V O R G
+ * N A C H V I E R T E L
+ * H A L B V O R N A C H
+ * E I N S K U R Z W E I
+ * D R E I A U J V I E R
+ * F Ü N F T O S E C H S
+ * S I E B E N L A C H T
+ * A N E U N M H Z E H N
+ * Z W Ö L F D T F E L F
+ * W A S D F U N K U H R
+ * + + + +
+ */
+
 class UHR_125_Type2_t : public iUhrType {
 public:
-    /*
-     * Layout Front
-     *
-     * E S K I S T A F Ü N F
-     * Z E H N D A U V O R G
-     * N A C H V I E R T E L
-     * H A L B V O R N A C H
-     * E I N S K U R Z W E I
-     * D R E I A U J V I E R
-     * F Ü N F T O S E C H S
-     * S I E B E N L A C H T
-     * A N E U N M H Z E H N
-     * Z W Ö L F D T F E L F
-     * W A S D F U N K U H R
-     * + + + +
-     */
-
-    const uint16_t min_arr[2][4] = {
-        // ergänzt aus "Uhr func 169"-datei
-        {121, 122, 123, 124}, // LED für Minuten Anzeige Zeile
-        {121, 122, 123, 124}  // LED für Minuten Anzeige Ecken
-    };
-
-    //------------------------------------------------------------------------------
-
-    virtual const uint16_t getMinArr(uint8_t col, uint8_t row) override {
-        return min_arr[col][row];
-    };
-
-    //------------------------------------------------------------------------------
-
     virtual const uint16_t NUM_PIXELS() override { return 125; };
 
     //------------------------------------------------------------------------------

--- a/include/Uhrtypes/uhr_func_242.hpp
+++ b/include/Uhrtypes/uhr_func_242.hpp
@@ -30,15 +30,12 @@
 
 class UHR_242_t : public iUhrType {
 public:
-    const uint16_t min_arr[2][4] = {
-        {112, 114, 116, 118}, // Minuten LED´s für Zeile
-        {112, 114, 116, 118}  // Minuten LED´s für Ecken
-    };
+    const uint16_t min_arr[4] = {112, 114, 116, 118}; // Minuten LED´s für Zeile
 
     //------------------------------------------------------------------------------
 
     virtual const uint16_t getMinArr(uint8_t col, uint8_t row) override {
-        return min_arr[col][row];
+        return min_arr[row];
     };
 
     //------------------------------------------------------------------------------

--- a/include/Uhrtypes/uhr_func_291.hpp
+++ b/include/Uhrtypes/uhr_func_291.hpp
@@ -24,16 +24,6 @@
 
 class UHR_291_t : public iUhrType {
 public:
-    const uint16_t min_arr[2][4] = {{288, 289, 290, 290}, {288, 289, 290, 290}};
-
-    //------------------------------------------------------------------------------
-
-    virtual const uint16_t getMinArr(uint8_t col, uint8_t row) override {
-        return min_arr[col][row];
-    };
-
-    //------------------------------------------------------------------------------
-
     virtual const uint16_t NUM_PIXELS() override { return 291; };
 
     //------------------------------------------------------------------------------

--- a/include/clockWork.h
+++ b/include/clockWork.h
@@ -14,7 +14,6 @@ private:
 
 private:
     void loopSecondsFrame();
-    void loopWeather();
     void loopLdrLogic();
 
     void rainbow();
@@ -22,14 +21,13 @@ private:
     void scrollingText(const char *buf);
 
     bool changesInClockface();
-    void copyClockface(const uint16_t source[], uint16_t destination[]);
+    void copyClockface(const bool source[], bool destination[]);
     void calcClockface();
 
     void setClock();
     void setHour(const uint8_t std, const uint8_t voll);
     void setMinute(uint8_t min, uint8_t &offsetH, uint8_t &voll);
     void showMinute(uint8_t min);
-    void showWeather();
 
 public:
     ClockWork() = default;

--- a/include/clockWork.hpp
+++ b/include/clockWork.hpp
@@ -10,7 +10,7 @@ OpenWMap weather;
 
 //------------------------------------------------------------------------------
 
-void ClockWork::copyClockface(const uint16_t source[], uint16_t destination[]) {
+void ClockWork::copyClockface(const bool source[], bool destination[]) {
     for (uint16_t i = 0; i < usedUhrType->NUM_PIXELS(); i++) {
         destination[i] = source[i];
     }
@@ -259,22 +259,8 @@ void ClockWork::showMinute(uint8_t min) {
         while (min > 4) {
             min -= 5;
         }
-
-        if (min > 0) {
-            frontMatrix[usedUhrType->getMinArr(G.minuteVariant - 1, 0)] =
-                usedUhrType->getMinArr(G.minuteVariant - 1, 0);
-        }
-        if (min > 1) {
-            frontMatrix[usedUhrType->getMinArr(G.minuteVariant - 1, 1)] =
-                usedUhrType->getMinArr(G.minuteVariant - 1, 1);
-        }
-        if (min > 2) {
-            frontMatrix[usedUhrType->getMinArr(G.minuteVariant - 1, 2)] =
-                usedUhrType->getMinArr(G.minuteVariant - 1, 2);
-        }
-        if (min > 3) {
-            frontMatrix[usedUhrType->getMinArr(G.minuteVariant - 1, 3)] =
-                usedUhrType->getMinArr(G.minuteVariant - 1, 3);
+        for (uint8_t i = 0; i < min; i++) {
+            frontMatrix[usedUhrType->getMinArr(G.minuteVariant - 1, i)] = true;
         }
     }
 }

--- a/include/led.hpp
+++ b/include/led.hpp
@@ -145,7 +145,7 @@ inline void Led::clearPixel(uint16_t i) {
 
 inline void Led::clear() {
     for (uint16_t i = 0; i < usedUhrType->NUM_PIXELS(); i++) {
-        frontMatrix[i] = 500;
+        frontMatrix[i] = false;
         clearPixel(i);
     }
 }
@@ -195,7 +195,7 @@ void Led::set(bool changed) {
     setBrightnessLdr(rr, gg, bb, ww, Foreground);
     setBrightnessLdr(r2, g2, b2, w2, Background);
     for (uint16_t i = 0; i < usedUhrType->NUM_PIXELS(); i++) {
-        if (lastFrontMatrix[i] < usedUhrType->NUM_PIXELS()) {
+        if (lastFrontMatrix[i]) {
             // foreground
             setPixel(rr, gg, bb, ww, i);
         } else {


### PR DESCRIPTION
Instead of writing every information about the LED No. in an array with corresponding number as value the frontMatrix now consist of just a bool value with on/off representation. 

the minArray of the Uhrtypes are now calculated instead of const values.