### PR TITLE
Refactor of Uhrtype names and added language Front

### DIFF
--- a/include/Uhr.h
+++ b/include/Uhr.h
@@ -64,7 +64,7 @@ struct GLOBAL {
     uint8_t client_nr;
     uint8_t secondVariant;
     uint8_t minuteVariant;
-    bool languageVariant[5];
+    bool languageVariant[6];
     char timeserver[PAYLOAD_LENGTH];
     char hostname[PAYLOAD_LENGTH];
     char scrollingText[PAYLOAD_LENGTH];
@@ -143,6 +143,7 @@ enum LanguageDialects {
     ItIs40 = 2,
     ItIs45 = 3,
     NotShowItIs = 4,
+    ENG_Aquarter = 5,
 };
 
 enum CommandWords {
@@ -190,15 +191,16 @@ enum CommandWords {
 };
 
 enum ClockType {
-    Uhr_114 = 1,
-    Uhr_114_Alternative = 2,
-    Uhr_114_2Clock = 6,
-    Uhr_114_Dutch = 9,
-    Uhr_125 = 3,
-    Uhr_125_Type2 = 8,
-    Uhr_169 = 4,
-    Uhr_242 = 5,
-    Uhr_291 = 7,
+    Ger10x11 = 1,
+    Ger10x11Alternative = 2,
+    Ger10x11Clock = 6,
+    Nl10x11 = 9,
+    Ger11x11 = 3,
+    Ger11x11V2 = 8,
+    Ger10x11Frame = 4,
+    Ger21x11Weather = 5,
+    Ger17x17 = 7,
+    Eng10x11 = 10,
 };
 
 enum Icons {

--- a/include/Uhrtypes/DE10x11.2clock.hpp
+++ b/include/Uhrtypes/DE10x11.2clock.hpp
@@ -16,7 +16,7 @@
  *
  */
 
-class UHR_114_2Clock_t : public iUhrType {
+class De10x11Clock_t : public iUhrType {
 public:
     virtual const bool hasDreiviertel() override { return true; }
 
@@ -214,4 +214,4 @@ public:
     };
 };
 
-UHR_114_2Clock_t Uhr_114_2Clock_type;
+De10x11Clock_t _de10x11Clock;

--- a/include/Uhrtypes/DE10x11.alternative.hpp
+++ b/include/Uhrtypes/DE10x11.alternative.hpp
@@ -18,7 +18,7 @@
 
 #define USE_DREIVIERTEL
 
-class UHR_114_Alternative_t : public iUhrType {
+class De10x11Alternative_t : public iUhrType {
 public:
     virtual const bool hasDreiviertel() override { return true; }
 
@@ -240,4 +240,4 @@ public:
     };
 };
 
-UHR_114_Alternative_t Uhr_114_Alternative_type;
+De10x11Alternative_t _de10x11Alternative;

--- a/include/Uhrtypes/DE10x11.frame.hpp
+++ b/include/Uhrtypes/DE10x11.frame.hpp
@@ -16,7 +16,7 @@
 156,157,158,159,160,161,162,163,164,165,166,167,168
 */
 
-class UHR_169_t : public iUhrType {
+class De10x11frame_t : public iUhrType {
 public:
     const uint16_t rmatrix[48] = {
         0,   1,   2,   3,   4,   5,   6,   7,   8,   9,   10,  11,
@@ -257,4 +257,4 @@ public:
     };
 };
 
-UHR_169_t Uhr_169_type;
+De10x11frame_t _de10x11frame;

--- a/include/Uhrtypes/DE10x11.hpp
+++ b/include/Uhrtypes/DE10x11.hpp
@@ -19,7 +19,7 @@
 
 #define LED_MAP(x) (x)
 
-class UHR_114_t : public iUhrType {
+class De10x11_t : public iUhrType {
 public:
 #if (LED_LAYOUT_REVERSE)
 
@@ -314,4 +314,4 @@ public:
     };
 };
 
-UHR_114_t Uhr_114_type;
+De10x11_t _de10x11;

--- a/include/Uhrtypes/DE11x11.hpp
+++ b/include/Uhrtypes/DE11x11.hpp
@@ -17,7 +17,7 @@
  * + + + +
  */
 
-class UHR_125_t : public iUhrType {
+class De11x11_t : public iUhrType {
 public:
     const uint16_t min_arr[2][4] = {
         {110, 111, 112, 113}, // LED für Minuten Anzeige Zeile
@@ -218,4 +218,4 @@ public:
     };
 };
 
-UHR_125_t Uhr_125_type;
+De11x11_t _de11x11;

--- a/include/Uhrtypes/DE11x11.v2.hpp
+++ b/include/Uhrtypes/DE11x11.v2.hpp
@@ -17,7 +17,7 @@
  * + + + +
  */
 
-class UHR_125_Type2_t : public iUhrType {
+class De11x11V2_t : public iUhrType {
 public:
     virtual const uint16_t NUM_PIXELS() override { return 125; };
 
@@ -268,4 +268,4 @@ public:
     };
 };
 
-UHR_125_Type2_t Uhr_125_type2_type;
+De11x11V2_t _de11x11V2;

--- a/include/Uhrtypes/DE17x17.hpp
+++ b/include/Uhrtypes/DE17x17.hpp
@@ -22,7 +22,7 @@
  *
  */
 
-class UHR_291_t : public iUhrType {
+class De17x17_t : public iUhrType {
 public:
     virtual const uint16_t NUM_PIXELS() override { return 291; };
 
@@ -480,4 +480,4 @@ public:
     };
 };
 
-UHR_291_t Uhr_291_type;
+De17x17_t _de17x17;

--- a/include/Uhrtypes/DE21x11.weather.hpp
+++ b/include/Uhrtypes/DE21x11.weather.hpp
@@ -28,7 +28,7 @@
  * D R E I ẞ I G O ° C X
  */
 
-class UHR_242_t : public iUhrType {
+class De21x11Weather_t : public iUhrType {
 public:
     const uint16_t min_arr[4] = {112, 114, 116, 118}; // Minuten LED´s für Zeile
 
@@ -576,4 +576,4 @@ public:
     };
 };
 
-UHR_242_t Uhr_242_type;
+De21x11Weather_t _de21x11Weather;

--- a/include/Uhrtypes/EN10x11.hpp
+++ b/include/Uhrtypes/EN10x11.hpp
@@ -1,0 +1,219 @@
+#include "Uhrtype.hpp"
+
+/*
+ * Layout Front
+ *
+ * I T L I S A S A M P M
+ * A C Q U A R T E R D C
+ * T W E N T Y F I V E X
+ * H A L F S T E N F T O
+ * P A S T E R U N I N E
+ * O N E S I X T H R E E
+ * F O U R F I V E T W O
+ * E I G H T E L E V E N
+ * S E V E N T W E L V E
+ * T E N S E O'C L O C K
+ *
+ */
+
+#define USE_DREIVIERTEL
+
+class En10x11_t : public iUhrType {
+public:
+    virtual const bool hasZwanzig() override { return true; }
+
+    //------------------------------------------------------------------------------
+
+    virtual const bool hasTwentyfive() override { return true; }
+
+    //------------------------------------------------------------------------------
+
+    void show(uint8_t text) override {
+        switch (text) {
+
+        case es_ist:
+            // Es
+            Letter_set(0); // I
+            Letter_set(1); // T
+            // Ist
+            Letter_set(3); // I
+            Letter_set(4); // S
+            break;
+        case h_ein:
+            // One
+            Letter_set(65); // O
+            Letter_set(64); // N
+            Letter_set(63); // E
+            break;
+        case h_zwei:
+            // Two
+            Letter_set(74); // T
+            Letter_set(75); // W
+            Letter_set(76); // O
+            break;
+        case h_drei:
+            // Three
+            Letter_set(59); // T
+            Letter_set(58); // H
+            Letter_set(57); // R
+            Letter_set(56); // E
+            Letter_set(55); // E
+            break;
+        case h_vier:
+            // Four
+            Letter_set(66); // F
+            Letter_set(67); // O
+            Letter_set(68); // U
+            Letter_set(69); // R
+            break;
+        case h_fuenf:
+            // Five
+            Letter_set(70); // F
+            Letter_set(71); // I
+            Letter_set(72); // V
+            Letter_set(73); // E
+            break;
+        case h_sechs:
+            // Six
+            Letter_set(62); // S
+            Letter_set(61); // I
+            Letter_set(60); // X
+            break;
+        case h_sieben:
+            // Seven
+            Letter_set(88); // S
+            Letter_set(89); // E
+            Letter_set(90); // V
+            Letter_set(91); // E
+            Letter_set(92); // N
+            break;
+        case h_acht:
+            // Eight
+            Letter_set(87); // E
+            Letter_set(86); // I
+            Letter_set(85); // G
+            Letter_set(84); // H
+            Letter_set(83); // T
+            break;
+        case h_neun:
+            // Nine
+            Letter_set(51); // N
+            Letter_set(52); // I
+            Letter_set(53); // N
+            Letter_set(54); // E
+            break;
+        case h_zehn:
+            // Ten
+            Letter_set(109); // T
+            Letter_set(108); // E
+            Letter_set(107); // N
+            break;
+        case h_elf:
+            // Eleven
+            Letter_set(82); // E
+            Letter_set(81); // L
+            Letter_set(80); // E
+            Letter_set(79); // V
+            Letter_set(78); // E
+            Letter_set(77); // N
+            break;
+        case h_zwoelf:
+            // Twelve
+            Letter_set(93); // T
+            Letter_set(94); // W
+            Letter_set(95); // E
+            Letter_set(96); // L
+            Letter_set(97); // V
+            Letter_set(98); // E
+            break;
+        case fuenf:
+            // Five
+            Letter_set(28); // F
+            Letter_set(29); // I
+            Letter_set(30); // V
+            Letter_set(31); // E
+            break;
+        case zehn:
+            // Ten
+            Letter_set(38); // T
+            Letter_set(37); // E
+            Letter_set(36); // N
+            break;
+        case a_quarter:
+            // A Quater
+            Letter_set(21); // A
+            Letter_set(13); // Q
+            Letter_set(14); // U
+            Letter_set(15); // A
+            Letter_set(16); // R
+            Letter_set(17); // T
+            Letter_set(18); // E
+            Letter_set(19); // R
+            break;
+        case viertel:
+            // Quater
+            Letter_set(13); // Q
+            Letter_set(14); // U
+            Letter_set(15); // A
+            Letter_set(16); // R
+            Letter_set(17); // T
+            Letter_set(18); // E
+            Letter_set(19); // R
+            break;
+        case zwanzig:
+            // Twenty
+            Letter_set(22); // T
+            Letter_set(23); // W
+            Letter_set(24); // E
+            Letter_set(25); // N
+            Letter_set(26); // T
+            Letter_set(27); // Y
+            break;
+        case twentyfive:
+            // Twentyfive
+            Letter_set(22); // T
+            Letter_set(23); // W
+            Letter_set(24); // E
+            Letter_set(25); // N
+            Letter_set(26); // T
+            Letter_set(27); // Y
+            Letter_set(28); // F
+            Letter_set(29); // I
+            Letter_set(30); // V
+            Letter_set(31); // E
+            break;
+        case halb:
+            // Half
+            Letter_set(43); // H
+            Letter_set(42); // A
+            Letter_set(41); // L
+            Letter_set(40); // F
+            break;
+        case nach:
+            // Past
+            Letter_set(44); // P
+            Letter_set(45); // A
+            Letter_set(46); // S
+            Letter_set(47); // T
+            break;
+        case vor:
+            // To
+            Letter_set(34); // T
+            Letter_set(33); // O
+            break;
+        case uhr:
+            // O'Clock
+            Letter_set(104); // O'
+            Letter_set(103); // C
+            Letter_set(102); // L
+            Letter_set(101); // O
+            Letter_set(100); // C
+            Letter_set(99);  // K
+            break;
+        default:
+            break;
+        };
+    };
+};
+
+En10x11_t _en10x11;

--- a/include/Uhrtypes/Uhrtype.hpp
+++ b/include/Uhrtypes/Uhrtype.hpp
@@ -21,6 +21,7 @@ enum ledText {
     m_achtzehn = 18,
     m_neunzehn = 19,
     zwanzig = 20,
+    twentyfive = 25,
 
     es_ist = 101,
     nach = 102,
@@ -43,6 +44,7 @@ enum ledText {
     minuten_uhr = 122,
     v_vor = 123,
     v_nach = 124,
+    a_quarter = 125,
 
     h_ein = 151,
     h_zwei = 152,
@@ -107,6 +109,8 @@ public:
     virtual const bool hasDreiviertel() { return false; }
 
     virtual const bool hasZwanzig() { return true; }
+
+    virtual const bool hasTwentyfive() { return false; }
 
     virtual const bool has24HourLayout() { return false; }
 

--- a/include/Uhrtypes/nl10x11.hpp
+++ b/include/Uhrtypes/nl10x11.hpp
@@ -16,7 +16,7 @@
  *
  */
 
-class UHR_114_dutch_t : public iUhrType {
+class Nl10x11_t : public iUhrType {
 public:
     virtual const bool hasZwanzig() override { return false; }
 
@@ -177,4 +177,4 @@ public:
     };
 };
 
-UHR_114_dutch_t Uhr_114_dutch_type;
+Nl10x11_t _nl10x11;

--- a/include/clockWork.hpp
+++ b/include/clockWork.hpp
@@ -168,7 +168,7 @@ void ClockWork::setHour(const uint8_t std, const uint8_t voll) {
         usedUhrType->show(h_zwoelf);
         break;
     case 1:
-        if (voll == 1) {
+        if (voll == 1 || G.UhrtypeDef == Eng10x11) {
             usedUhrType->show(h_ein);
         } else {
             usedUhrType->show(eins);
@@ -208,7 +208,7 @@ void ClockWork::setHour(const uint8_t std, const uint8_t voll) {
         usedUhrType->show(h_zwoelf);
         break;
     case 13:
-        if (voll == 1) {
+        if (voll == 1 || G.UhrtypeDef == Eng10x11) {
             usedUhrType->show(h_ein);
         } else {
             usedUhrType->show(eins);
@@ -305,7 +305,12 @@ void ClockWork::setMinute(uint8_t min, uint8_t &offsetH, uint8_t &voll) {
             usedUhrType->show(viertel);
             offsetH = 1;
         } else {
-            usedUhrType->show(viertel);
+            // A Quarter past
+            if (G.languageVariant[ENG_Aquarter]) {
+                usedUhrType->show(a_quarter);
+            } else {
+                usedUhrType->show(viertel);
+            }
             usedUhrType->show(v_nach);
         }
         break;
@@ -332,6 +337,16 @@ void ClockWork::setMinute(uint8_t min, uint8_t &offsetH, uint8_t &voll) {
     case 23:
     case 24:
     case 25:
+        if (usedUhrType->hasTwentyfive()) {
+            usedUhrType->show(twentyfive);
+            usedUhrType->show(nach);
+        } else {
+            usedUhrType->show(fuenf);
+            usedUhrType->show(vor);
+            usedUhrType->show(halb);
+            offsetH = 1;
+        }
+        break;
     case 26:
     case 27:
     case 28:
@@ -348,8 +363,13 @@ void ClockWork::setMinute(uint8_t min, uint8_t &offsetH, uint8_t &voll) {
         offsetH = 1;
         break;
     case 30: // half
-        usedUhrType->show(halb);
-        offsetH = 1;
+        if (G.UhrtypeDef == Eng10x11) {
+            usedUhrType->show(halb);
+            usedUhrType->show(nach);
+        } else {
+            usedUhrType->show(halb);
+            offsetH = 1;
+        }
         break;
     case 31:
         usedUhrType->show(m_eine);
@@ -362,6 +382,17 @@ void ClockWork::setMinute(uint8_t min, uint8_t &offsetH, uint8_t &voll) {
     case 33:
     case 34:
     case 35:
+        if (usedUhrType->hasTwentyfive()) {
+            usedUhrType->show(twentyfive);
+            usedUhrType->show(vor);
+            offsetH = 1;
+        } else {
+            usedUhrType->show(fuenf);
+            usedUhrType->show(nach);
+            usedUhrType->show(halb);
+            offsetH = 1;
+        }
+        break;
     case 36:
     case 37:
     case 38:
@@ -394,8 +425,17 @@ void ClockWork::setMinute(uint8_t min, uint8_t &offsetH, uint8_t &voll) {
         if (usedUhrType->hasDreiviertel() && G.languageVariant[ItIs45]) {
             usedUhrType->show(dreiviertel);
         } else {
-            usedUhrType->show(viertel);
-            usedUhrType->show(v_vor);
+            // A Quarter to
+            if (G.languageVariant[ENG_Aquarter]) {
+                usedUhrType->show(a_quarter);
+            } else {
+                usedUhrType->show(viertel);
+            }
+            if (G.UhrtypeDef == Eng10x11) {
+                usedUhrType->show(vor);
+            } else {
+                usedUhrType->show(v_vor);
+            }
         }
         offsetH = 1;
         break;
@@ -532,24 +572,26 @@ void ClockWork::calcClockface() {
 
 iUhrType *ClockWork::getPointer(uint8_t type) {
     switch (type) {
-    case Uhr_114:
-        return &Uhr_114_type;
-    case Uhr_114_Alternative:
-        return &Uhr_114_Alternative_type;
-    case Uhr_114_2Clock:
-        return &Uhr_114_2Clock_type;
-    case Uhr_114_Dutch:
-        return &Uhr_114_dutch_type;
-    case Uhr_125:
-        return &Uhr_125_type;
-    case Uhr_125_Type2:
-        return &Uhr_125_type2_type;
-    case Uhr_169:
-        return &Uhr_169_type;
-    case Uhr_242:
-        return &Uhr_242_type;
-    case Uhr_291:
-        return &Uhr_291_type;
+    case Ger10x11:
+        return &_de10x11;
+    case Ger10x11Alternative:
+        return &_de10x11Alternative;
+    case Ger10x11Clock:
+        return &_de10x11Clock;
+    case Nl10x11:
+        return &_nl10x11;
+    case Ger11x11:
+        return &_de11x11;
+    case Ger11x11V2:
+        return &_de11x11V2;
+    case Ger10x11Frame:
+        return &_de10x11frame;
+    case Ger21x11Weather:
+        return &_de21x11Weather;
+    case Ger17x17:
+        return &_de17x17;
+    case Eng10x11:
+        return &_en10x11;
     default:
         return nullptr;
     }
@@ -561,7 +603,8 @@ void ClockWork::initLedStrip(uint8_t num) {
     NeoMultiFeature::setColortype(num);
     if (num == Grbw) {
         if (strip_RGB != NULL) {
-            delete strip_RGB; // delete the previous dynamically created strip
+            delete strip_RGB; // delete the previous dynamically created
+                              // strip
             strip_RGB = NULL;
         }
         if (strip_RGBW == NULL) {
@@ -571,7 +614,8 @@ void ClockWork::initLedStrip(uint8_t num) {
         }
     } else {
         if (strip_RGBW != NULL) {
-            delete strip_RGBW; // delete the previous dynamically created strip
+            delete strip_RGBW; // delete the previous dynamically created
+                               // strip
             strip_RGBW = NULL;
         }
         if (strip_RGB == NULL) {
@@ -687,7 +731,7 @@ void ClockWork::loop(struct tm &tm) {
         config["h20"] = G.h20;
         config["h22"] = G.h22;
         config["h24"] = G.h24;
-        for (uint8_t i = 0; i < 5; i++) {
+        for (uint8_t i = 0; i < 6; i++) {
             char stringToSend[11];
             sprintf(stringToSend, "langVar%d", i);
             config[stringToSend] = static_cast<uint8_t>(G.languageVariant[i]);

--- a/include/config.h
+++ b/include/config.h
@@ -4,26 +4,29 @@
  */
 
 // Layout der Frontplatte:
-// - Uhr_114
+// - Ger10x11
 //   10 Reihen, jeweils 11 LED's pro Reihe + 4 LED's für Minuten
-// - Uhr_114_Alternative
+// - Ger10x11Alternative
 //   10 Reihen, jeweils 11 LED's pro Reihe + 4 LED's für Minuten, mit geändertem
 //   Layout für extra Wörter in der Matrix
-// - Uhr_114_2Clock
+// - Ger10x11Clock
 //   10 Reihen, jeweils 11 LED's pro Reihe + 4 LED's für Minuten, mit dem Layout
 //   vom orginal Hersteller
-// - Uhr_114_Dutch
+// - Nl10x11
 //   10 Reihen, jeweils 11 LED's pro Reihe + 4 LED's für Minuten, mit geändertem
 //   Layout für die niederländische Sprache
-// - Uhr_125
+// - Eng10x11
+//   10 Reihen, jeweils 11 LED's pro Reihe + 4 LED's für Minuten, mit geändertem
+//   Layout für die englische Sprache
+// - Ger11x11
 //   11 Reihen, jeweils 11 LED's pro Reihe + 4 LED's für Minuten
-// - Uhr_169
+// - Ger10x11Frame
 //   mit zusätzlichen LED's um den Rahmen seitlich zu beleuchten
-// - Uhr_242
+// - Ger21x11Weather
 //   Uhr mit Wettervorhersage 242 LED's
-// - Uhr_291
+// - Ger17x17
 //   Uhr mit 24 Stunden Anzeige 18x16
-#define DEFAULT_LAYOUT Uhr_114
+#define DEFAULT_LAYOUT Ger10x11Alternative
 
 // Typ der LEDs:
 // - Brg, Grb, Rgb, Rbg (WS2812b)

--- a/include/webPageAdapter.h
+++ b/include/webPageAdapter.h
@@ -373,6 +373,7 @@ void webSocketEvent(uint8_t num, WStype_t type, uint8_t *payload,
             G.languageVariant[ItIs40] = split(payload, 9);
             G.languageVariant[ItIs45] = split(payload, 12);
             G.languageVariant[NotShowItIs] = split(payload, 15);
+            G.languageVariant[ENG_Aquarter] = split(payload, 18);
             break;
         }
 

--- a/src/Wortuhr.cpp
+++ b/src/Wortuhr.cpp
@@ -173,7 +173,7 @@ void setup() {
         G.h20 = 100;
         G.h22 = 100;
         G.h24 = 100;
-        for (uint8_t i = 0; i < 5; i++) {
+        for (uint8_t i = 0; i < 6; i++) {
             G.languageVariant[i] = false;
         }
 

--- a/webpage/index.html
+++ b/webpage/index.html
@@ -200,15 +200,16 @@
                                 <fieldset>
                                     <div class="pure-control-group">
                                         <label for="front-layout">Änderung des Uhrentypes.</label><select name="front-layout" id="front-layout" size="1">
-                                        <option value="1" selected>Uhr 114</option>
-                                        <option value="2">Uhr 114 Alternative</option>
-                                        <option value="6">Uhr 114 2Clock</option>
-                                        <option value="9">Uhr 114 Dutch</option>
-                                        <option value="3">Uhr 125</option>
-                                        <option value="8">Uhr 125 Type2</option>
-                                        <option value="4">Uhr 169</option>
-                                        <option value="5">Uhr 242</option>
-                                        <option value="7">Uhr 291</option>
+                                        <option value="1" selected>DE 10x11</option>
+                                        <option value="2">DE 10x11 Alternative</option>
+                                        <option value="6">DE 10x11 Clock</option>
+                                        <option value="3">DE 11x11</option>
+                                        <option value="8">DE 11x11 v2</option>
+                                        <option value="4">DE 10x11 Frame</option>
+                                        <option value="5">DE 21x11 Weather</option>
+                                        <option value="7">DE 17x17 </option>
+                                        <option value="10">EN 10x11</option>
+                                        <option value="9">Nl 10x11</option>
                                     </select>
                                     </div>
                                 </fieldset>
@@ -238,14 +239,22 @@
                                         <option value="1">zehn nach halb zehn</option>
                                     </select>
                                     </div>
-                                    <!-- Specific UHR114_Alternative Start-->
+                                    <!-- Specific DE10x11Alternative Start-->
                                     <div class="pure-control-group specific-layout-2">
                                         <label for="dialect-3">Um 9:45 ist es...</label><select name="dialect-3" id="dialect-3" size="1">
                                         <option value="0" selected>viertel vor zehn</option>
                                         <option value="1">dreiviertel zehn</option>
                                     </select>
                                     </div>
-                                    <!-- Specific UHR114_Alternative End-->
+                                    <!-- Specific DE10x11Alternative End-->
+                                    <!-- Specific EN10x11 Start-->
+                                    <div class="pure-control-group specific-layout-6">
+                                        <label for="dialect-5">On 9:45 it is ...</label><select name="dialect-5" id="dialect-5" size="1">
+                                        <option value="0" selected>Quarter to ten</option>
+                                        <option value="1">A quarter to ten</option>
+                                    </select>
+                                    </div>
+                                    <!-- Specific EN10x11 End-->
                                     <div class="pure-control-group">
                                         <label for="dialect-4">"Es ist" ausblenden</label>
                                         <label class="switch">

--- a/webpage/script.js
+++ b/webpage/script.js
@@ -80,7 +80,7 @@ var h18 = 100;
 var h20 = 100;
 var h22 = 100;
 var h24 = 100;
-var dialect = [0, 0, 0, 0, 0];
+var dialect = [0, 0, 0, 0, 0, 0];
 var ldr = 0;
 var ldrCal = 0;
 var showSeconds = 0;
@@ -197,7 +197,7 @@ function initConfigValues() {
 	h24 = 100;
 	ldr = 0;
 	ldrCal = 10;
-	dialect = [0, 0, 0, 0, 0];
+	dialect = [0, 0, 0, 0, 0, 0];
 	showSeconds = 0;
 	showMinutes = 0;
 	UhrtypeDef = 0;
@@ -322,6 +322,7 @@ function initWebsocket() {
 			$("#dialect-2").set("value", data.langVar2);
 			$("#dialect-3").set("value", data.langVar3);
 			document.getElementById("dialect-4").checked = data.langVar4;
+			$("#dialect-5").set("value", data.langVar5);
 
 			document.getElementById("ldr").checked = data.ldr;
 			$("ldr-cal").set("value", data.ldrCal);
@@ -345,6 +346,7 @@ function initWebsocket() {
 			enableSpecific("specific-layout-3", data.hasZwanzig);
 			enableSpecific("specific-layout-4", data.hasSecondsFrame);
 			enableSpecific("specific-layout-5", data.hasWeatherLayout);
+			enableSpecific("specific-layout-6", data.UhrtypeDef === 10); // En10x11
 			enableSpecific("specific-colortype-4", data.colortype === 4);
 
 			autoLdrEnabled = data.autoLdrEnabled;
@@ -925,8 +927,9 @@ $.ready(function() {
 		dialect[2] = $("#dialect-2").get("value");
 		dialect[3] = $("#dialect-3").get("value");
 		dialect[4] = $("#dialect-4").get("checked") | 0;
+		dialect[5] = $("#dialect-5").get("value");
 
-		sendCmd(COMMAND_SET_LANGUAGE_VARIANT, nstr(dialect[0]) + nstr(dialect[1]) + nstr(dialect[2]) + nstr(dialect[3]) + nstr(dialect[4]));
+		sendCmd(COMMAND_SET_LANGUAGE_VARIANT, nstr(dialect[0]) + nstr(dialect[1]) + nstr(dialect[2]) + nstr(dialect[3]) + nstr(dialect[4]) + nstr(dialect[5]));
 		debugMessage("langVar" + debugMessageReconfigured);
 	});
 });


### PR DESCRIPTION
Refactor of Uhrtype names to a more univeral aproach. Added new language Front "English 10x11" with dialect options.

 Changes to be committed:
	modified:   include/Uhr.h
	renamed:    include/Uhrtypes/uhr_func_114_2Clock.hpp -> include/Uhrtypes/DE10x11.2clock.hpp
	renamed:    include/Uhrtypes/uhr_func_114_Alternative.hpp -> include/Uhrtypes/DE10x11.alternative.hpp
	renamed:    include/Uhrtypes/uhr_func_169.hpp -> include/Uhrtypes/DE10x11.frame.hpp
	renamed:    include/Uhrtypes/uhr_func_114.hpp -> include/Uhrtypes/DE10x11.hpp
	renamed:    include/Uhrtypes/uhr_func_125.hpp -> include/Uhrtypes/DE11x11.hpp
	renamed:    include/Uhrtypes/uhr_func_125_Type2.hpp -> include/Uhrtypes/DE11x11.v2.hpp
	renamed:    include/Uhrtypes/uhr_func_291.hpp -> include/Uhrtypes/DE17x17.hpp
	renamed:    include/Uhrtypes/uhr_func_242.hpp -> include/Uhrtypes/DE21x11.weather.hpp
	new file:   include/Uhrtypes/EN10x11.hpp
	modified:   include/Uhrtypes/Uhrtype.hpp
	renamed:    include/Uhrtypes/uhr_func_114_dutch.hpp -> include/Uhrtypes/nl10x11.hpp
	modified:   include/clockWork.hpp
	modified:   include/config.h
	modified:   include/webPageAdapter.h
	modified:   src/Wortuhr.cpp
	modified:   webpage/index.html
	modified:   webpage/script.js