### PR TITLE
Mehrfache Einträge beim Dropdown *Funktionen* > *Animation* > *Art* behoben

### DIFF
--- a/webpage/script.js
+++ b/webpage/script.js
@@ -427,11 +427,15 @@ function initWebsocket() {
 			var index;
 			var animSelect = document.getElementById("animation-types");
 			var option;
+
+			while (animSelect.options.length > 0) {
+				select.remove(0);
+			}
+
 			for (index = 0; index < animTypes.length; index++) {
 				option = document.createElement("option");
 				option.value = index;
 				option.text = animTypes[index];
-				animSelect.remove(index);
 				animSelect.add(option);
 			}
 			setAnimation();

--- a/webpage/script.js
+++ b/webpage/script.js
@@ -429,7 +429,7 @@ function initWebsocket() {
 			var option;
 
 			while (animSelect.options.length > 0) {
-				select.remove(0);
+				animSelect.remove(0);
 			}
 
 			for (index = 0; index < animTypes.length; index++) {


### PR DESCRIPTION
Dieser PR behebt hoffentlich das Problem #144, wobei mehrfache Einträge im Dropdown bei *Funktionen* > *Animation* > *Art* auftreten. Wahrscheinlich liegt es an dem gleichzeitigen Entfernen und Hinzufügen von Einträgen des Selects.

Bei mir tritt das Problem #114 nur auf dem iPhone (iOS 16.1.1) im Safari auf. Auf dem Desktop im Firefox 109.0.1 und auch im Safari Version 15.1 (17612.2.9.1.20) kann ich es nicht reproduzieren. Ich kann somit nicht garantieren, dass das Problem #114 behoben ist, bis ich diese Bugfix mal auf meiner Wortuhr aufspiele und teste ... bin aber zuversichtlich.