### PR TITLE
Fix empty language select in iOS Safari on initial page load

### DIFF
--- a/webpage/i18n.js
+++ b/webpage/i18n.js
@@ -41,6 +41,17 @@ function initLanguageDropdown(language) {
 
 	let languageSelect = document.getElementById("language");
 
+	// The following four lines are a bugfix for Safari on iOS.
+	// The state of the currently selected option would not change in the select until you click on
+	// it (showing an initial empty select).
+	// The workaround clones the complete select, removes it from the DOM and then adds it again. When changing
+	// the currently selected option on the clone, the UI updates accordingly even on iOS Safari.
+	// Interestingly the problem does not occur with Safari for macOS (or e.g. Firefox for macOS).
+	let cloneLanguageSelect = languageSelect.cloneNode(true);
+	languageSelect.remove();
+	document.getElementById("language-select-container").append(cloneLanguageSelect);
+	languageSelect = cloneLanguageSelect;
+
 	// set initial language for the dropdown
 	languageSelect.value = language;
 

--- a/webpage/index.html
+++ b/webpage/index.html
@@ -55,7 +55,7 @@
                 <li class="pure-menu-item"><a href="#" class="pure-menu-link" data-navigation="about" data-i18next="about.h1"></a></li>
 
                 <li class="pure-menu-heading"><label for="language" data-i18next="menu.language.label"></label></li>
-                <li class="pure-menu-item pure-form">
+                <li class="pure-menu-item pure-form" id="language-select-container">
                     <select id="language" class="language" size="1">
                         <option value="de" data-i18next="menu.language.de"></option>
                         <option value="en" data-i18next="menu.language.en"></option>


### PR DESCRIPTION
Dieser PR behebt einen Bug, den ich nur auf Safari für iOS nachstellen konnte. Beim initialen Laden der Seite war das Language-Select leer, obwohl dies etwas verzögert per JavaScript mit Inhalt gefüllt wird. Diese nachträgliche State-Änderung hat Safari erstmal nicht angezeigt, bzw. sie wurde angezeigt, wenn man das Select angeklickt/angetippt hat.

Der Workaround klont einfach das komplette Select aus dem HTML, entfernt das ursprüngliche Select und arbeitet auf dem Klon. Dann funktioniert auch alles im Safari auf iOS. Den Fehler konnte ich nicht mit Safari für macOS oder auch Firefox für macOS nachstellen.

---

This PR fixes a bug I was only able to replicate on Safari for iOS. When the page was initially loaded, the language select was empty, although this was filled with content via JavaScript with some delay. Safari did not display this subsequent state change at first, or it was displayed when you clicked/tapped on the select.

The workaround is simply cloning the entire select from the HTML, removing the original select and working on the clone. Then everything works in Safari for iOS. I could not reproduce the error with Safari for macOS or Firefox for macOS.

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>

<tr>
<td>
<img src="https://user-images.githubusercontent.com/17237627/232761667-d56eedb2-a8a5-4453-9590-3048d3af7667.PNG" alt="before fix safari ios wont update state of select">
</td>
<td>
<img src="https://user-images.githubusercontent.com/17237627/232761684-778c57ec-2ea6-4ffb-9dfd-c70a17f9c9ca.PNG" alt="after fix">
</td>
</tr>
</table>