### PR TITLE
MQTT Änderungen

### DIFF
--- a/configuration_example.yaml
+++ b/configuration_example.yaml
@@ -1,28 +1,31 @@
 # Example configuration.yaml entry
-light:
-  - platform: mqtt
-    schema: template
-    effect_list:
-      - Wortuhr
-      - Sekundenanzeige
-      - Laufschrift
-      - Regenbogen
-      - Farbwechsel
-      - Farbe
-    command_topic: "home/rgb1/set"
-    state_topic: "home/rgb1/status"
-    command_on_template: >
-      {"state": "on"
-      {%- if red is defined and green is defined and blue is defined -%}
-      , "color": [{{ red }}, {{ green }}, {{ blue }}]
-      {%- endif -%}
-      {%- if effect is defined -%}
-      , "effect": "{{ effect }}"
-      {%- endif -%}
-      }
-    command_off_template: '{"state": "off"}'
-    state_template: '{{ value_json.state }}'
-    red_template: '{{ value_json.color[0] }}'
-    green_template: '{{ value_json.color[1] }}'
-    blue_template: '{{ value_json.color[2] }}'
-    effect_template: '{{ value_json.effect }}'
+mqtt:
+  light:
+    - name: Wortuhr
+      unique_id: "wortuhr"
+      schema: template
+      effect_list:
+        - Wordclock
+        - Seconds
+        - Digitalclock
+        - Scrollingtext
+        - Rainbowcycle
+        - Rainbow
+        - Color
+      command_topic: "ESPWordclock"
+      # state_topic: "ESPWordclock"
+      command_on_template: >
+        {"state": "on"
+        {%- if red is defined and green is defined and blue is defined -%}
+        , "color": [{{ red }}, {{ green }}, {{ blue }}]
+        {%- endif -%}
+        {%- if effect is defined -%}
+        , "effect": "{{ effect }}"
+        {%- endif -%}
+        }
+      command_off_template: '{"state": "off"}'
+      state_template: '{{ value_json.state }}'
+      red_template: '{{ value_json.color[0] }}'
+      green_template: '{{ value_json.color[1] }}'
+      blue_template: '{{ value_json.color[2] }}'
+      effect_template: '{{ value_json.effect }}'

--- a/include/mqtt.hpp
+++ b/include/mqtt.hpp
@@ -98,6 +98,10 @@ void Mqtt::callback(char *topic, byte *payload, unsigned int length) {
         }
     }
 
+    if (doc.containsKey("marquee_text")) {
+        strcpy(G.scrollingText, doc["marquee_text"]);
+    }
+
     if (doc.containsKey("color")) {
         G.color[Foreground] =
             RgbColor(doc["color"][0], doc["color"][1], doc["color"][2]);

--- a/include/mqtt.hpp
+++ b/include/mqtt.hpp
@@ -101,7 +101,7 @@ void Mqtt::callback(char *topic, byte *payload, unsigned int length) {
     if (doc.containsKey("color")) {
         G.color[Foreground] =
             RgbColor(doc["color"][0], doc["color"][1], doc["color"][2]);
-        G.color[Foreground].alpha = doc["White"];
+        G.color[Foreground].alpha = 1;
     }
 }
 


### PR DESCRIPTION
Ich hab das Home-Assistant Beispiel mal an das neue Format und die letzten Änderungen im Wortuhr-Code angepasst.

Außerdem hab ich noch zwei kleine Änderungen im MQTT code gemacht: Der Marqee-Text ist jetzt anpassbar, dass man auch Nachrichten von Home-Assistant an die Uhr schicken kann.