### PR TITLE
Reworked Uhrtype handling from Index to 2D

### DIFF
--- a/include/Uhrtypes/DE10x11.2clock.hpp
+++ b/include/Uhrtypes/DE10x11.2clock.hpp
@@ -3,18 +3,20 @@
 #include "Uhrtype.hpp"
 
 /*
- * Layout Front
- *
- * E S K I S T A F Ü N F
- * Z E H N Z W A N Z I G
- * D R E I V I E R T E L
- * V O R F U N K N A C H
- * H A L B A E L F Ü N F
- * E I N S X A M Z W E I
- * D R E I A U J V I E R
- * S E C H S N L A C H T
- * S I E B E N Z W Ö L F
- * Z E H N E U N K U H R
+ *           Layout Front
+ *                COL
+ *       X 9 8 7 6 5 4 3 2 1 0
+ * ROW + - - - - - - - - - - -
+ *  0  | E S K I S T A F Ü N F
+ *  1  | Z E H N Z W A N Z I G
+ *  2  | D R E I V I E R T E L
+ *  3  | V O R F U N K N A C H
+ *  4  | H A L B A E L F Ü N F
+ *  5  | E I N S X A M Z W E I
+ *  6  | D R E I A U J V I E R
+ *  7  | S E C H S N L A C H T
+ *  8  | S I E B E N Z W Ö L F
+ *  9  | Z E H N E U N K U H R
  *
  */
 
@@ -34,193 +36,103 @@ public:
         switch (word) {
 
         case FrontWord::es_ist:
-            // Es
-            setFrontMatrixPixel(0);
-            setFrontMatrixPixel(1);
 
-            // Ist
-            setFrontMatrixPixel(3);
-            setFrontMatrixPixel(4);
-            setFrontMatrixPixel(5);
+            setFrontMatrixWord(0, 9, 10);
+            setFrontMatrixWord(0, 5, 7);
             break;
 
         case FrontWord::nach:
         case FrontWord::v_nach:
-            // NACH
-            setFrontMatrixPixel(36);
-            setFrontMatrixPixel(35);
-            setFrontMatrixPixel(34);
-            setFrontMatrixPixel(33);
+            setFrontMatrixWord(3, 0, 3);
             break;
 
         case FrontWord::vor:
         case FrontWord::v_vor:
-            // Vor
-            setFrontMatrixPixel(41);
-            setFrontMatrixPixel(42);
-            setFrontMatrixPixel(43);
+            setFrontMatrixWord(3, 8, 10);
             break;
 
         case FrontWord::viertel:
-            // Viertel
-            setFrontMatrixPixel(32);
-            setFrontMatrixPixel(31);
-            setFrontMatrixPixel(30);
-            setFrontMatrixPixel(29);
-            setFrontMatrixPixel(28);
-            setFrontMatrixPixel(27);
-            setFrontMatrixPixel(26);
+            setFrontMatrixWord(2, 0, 6);
             break;
 
         case FrontWord::dreiviertel:
-            setFrontMatrixPixel(32);
-            setFrontMatrixPixel(31);
-            setFrontMatrixPixel(30);
-            setFrontMatrixPixel(29);
-            setFrontMatrixPixel(28);
-            setFrontMatrixPixel(27);
-            setFrontMatrixPixel(26);
-            setFrontMatrixPixel(25);
-            setFrontMatrixPixel(24);
-            setFrontMatrixPixel(23);
-            setFrontMatrixPixel(22);
+            setFrontMatrixWord(2, 0, 10);
             break;
 
         case FrontWord::fuenf:
-            setFrontMatrixPixel(7);
-            setFrontMatrixPixel(8);
-            setFrontMatrixPixel(9);
-            setFrontMatrixPixel(10);
+            setFrontMatrixWord(0, 0, 3);
             break;
 
         case FrontWord::zehn:
-            setFrontMatrixPixel(21);
-            setFrontMatrixPixel(20);
-            setFrontMatrixPixel(19);
-            setFrontMatrixPixel(18);
+            setFrontMatrixWord(1, 7, 10);
             break;
 
         case FrontWord::zwanzig:
-            setFrontMatrixPixel(17);
-            setFrontMatrixPixel(16);
-            setFrontMatrixPixel(15);
-            setFrontMatrixPixel(14);
-            setFrontMatrixPixel(13);
-            setFrontMatrixPixel(12);
-            setFrontMatrixPixel(11);
+            setFrontMatrixWord(1, 0, 6);
             break;
 
         case FrontWord::halb:
-            setFrontMatrixPixel(44);
-            setFrontMatrixPixel(45);
-            setFrontMatrixPixel(46);
-            setFrontMatrixPixel(47);
+            setFrontMatrixWord(4, 7, 10);
             break;
 
         case FrontWord::eins:
-            setFrontMatrixPixel(65);
-            setFrontMatrixPixel(64);
-            setFrontMatrixPixel(63);
-            setFrontMatrixPixel(62);
+            setFrontMatrixWord(5, 7, 10);
             break;
 
         case FrontWord::uhr:
-            setFrontMatrixPixel(99);
-            setFrontMatrixPixel(100);
-            setFrontMatrixPixel(101);
+            setFrontMatrixWord(9, 0, 2);
             break;
 
         case FrontWord::h_ein:
-            setFrontMatrixPixel(63);
-            setFrontMatrixPixel(64);
-            setFrontMatrixPixel(65);
+            setFrontMatrixWord(5, 8, 10);
             break;
 
         case FrontWord::h_zwei:
-            setFrontMatrixPixel(55);
-            setFrontMatrixPixel(56);
-            setFrontMatrixPixel(57);
-            setFrontMatrixPixel(58);
+            setFrontMatrixWord(5, 0, 3);
             break;
 
         case FrontWord::h_drei:
-            setFrontMatrixPixel(66);
-            setFrontMatrixPixel(67);
-            setFrontMatrixPixel(68);
-            setFrontMatrixPixel(69);
+            setFrontMatrixWord(6, 7, 10);
             break;
 
         case FrontWord::h_vier:
-            setFrontMatrixPixel(73);
-            setFrontMatrixPixel(74);
-            setFrontMatrixPixel(75);
-            setFrontMatrixPixel(76);
+            setFrontMatrixWord(6, 0, 3);
             break;
 
         case FrontWord::h_fuenf:
-            setFrontMatrixPixel(51);
-            setFrontMatrixPixel(52);
-            setFrontMatrixPixel(53);
-            setFrontMatrixPixel(54);
+            setFrontMatrixWord(4, 0, 3);
             break;
 
         case FrontWord::h_sechs:
-            setFrontMatrixPixel(83);
-            setFrontMatrixPixel(84);
-            setFrontMatrixPixel(85);
-            setFrontMatrixPixel(86);
-            setFrontMatrixPixel(87);
+            setFrontMatrixWord(7, 6, 10);
             break;
 
         case FrontWord::h_sieben:
-            setFrontMatrixPixel(88);
-            setFrontMatrixPixel(89);
-            setFrontMatrixPixel(90);
-            setFrontMatrixPixel(91);
-            setFrontMatrixPixel(92);
-            setFrontMatrixPixel(93);
+            setFrontMatrixWord(8, 5, 10);
             break;
 
         case FrontWord::h_acht:
-            setFrontMatrixPixel(77);
-            setFrontMatrixPixel(78);
-            setFrontMatrixPixel(79);
-            setFrontMatrixPixel(80);
+            setFrontMatrixWord(7, 0, 3);
             break;
 
         case FrontWord::h_neun:
-            setFrontMatrixPixel(103);
-            setFrontMatrixPixel(104);
-            setFrontMatrixPixel(105);
-            setFrontMatrixPixel(106);
+            setFrontMatrixWord(9, 4, 7);
             break;
 
         case FrontWord::h_zehn:
-            setFrontMatrixPixel(106);
-            setFrontMatrixPixel(107);
-            setFrontMatrixPixel(108);
-            setFrontMatrixPixel(109);
+            setFrontMatrixWord(9, 7, 10);
             break;
 
         case FrontWord::h_elf:
-            setFrontMatrixPixel(49);
-            setFrontMatrixPixel(50);
-            setFrontMatrixPixel(51);
+            setFrontMatrixWord(4, 3, 5);
             break;
 
         case FrontWord::h_zwoelf:
-            setFrontMatrixPixel(94);
-            setFrontMatrixPixel(95);
-            setFrontMatrixPixel(96);
-            setFrontMatrixPixel(97);
-            setFrontMatrixPixel(98);
+            setFrontMatrixWord(8, 0, 4);
             break;
 
         case FrontWord::funk:
-            setFrontMatrixPixel(40);
-            setFrontMatrixPixel(39);
-            setFrontMatrixPixel(38);
-            setFrontMatrixPixel(37);
+            setFrontMatrixWord(3, 4, 7);
             break;
 
         default:

--- a/include/Uhrtypes/DE10x11.alternative.frame.hpp
+++ b/include/Uhrtypes/DE10x11.alternative.frame.hpp
@@ -3,18 +3,20 @@
 #include "DE10x11.alternative.hpp"
 
 /*
- * Layout Front
- *
- * E S K I S T L F Ü N F
- * Z E H N Z W A N Z I G
- * D R E I V I E R T E L
- * N A C H A P P Y V O R
- * H A L B I R T H D A Y
- * D R Z W Ö L F Ü N F X
- * Z E H N E U N D R E I
- * Z W E I N S I E B E N
- * E L F V I E R A C H T
- * S E C H S I U H R Y E
+ *           Layout Front
+ *                COL
+ *       X 9 8 7 6 5 4 3 2 1 0
+ * ROW + - - - - - - - - - - -
+ *  0  | E S K I S T L F Ü N F
+ *  1  | Z E H N Z W A N Z I G
+ *  2  | D R E I V I E R T E L
+ *  3  | N A C H A P P Y V O R
+ *  4  | H A L B I R T H D A Y
+ *  5  | D R Z W Ö L F Ü N F X
+ *  6  | Z E H N E U N D R E I
+ *  7  | Z W E I N S I E B E N
+ *  8  | E L F V I E R A C H T
+ *  9  | S E C H S I U H R Y E
  *
  */
 
@@ -29,7 +31,7 @@ public:
     //------------------------------------------------------------------------------
 
     virtual const uint16_t getFrameMatrixIndex(uint16_t index) override {
-        return rowsWordMatrix() * colsWordMatrix() + 4 /* Minutes */ + index;
+        return 114 + index;
     };
 
     //------------------------------------------------------------------------------
@@ -37,7 +39,7 @@ public:
     virtual const void getMinuteArray(uint16_t *returnArr,
                                       uint8_t col) override {
         for (uint8_t i = 0; i < 4; i++) {
-            returnArr[i] = rowsWordMatrix() * colsWordMatrix() + i;
+            returnArr[i] = 110 + i;
         }
     };
 };

--- a/include/Uhrtypes/DE10x11.alternative.hpp
+++ b/include/Uhrtypes/DE10x11.alternative.hpp
@@ -3,18 +3,20 @@
 #include "Uhrtype.hpp"
 
 /*
- * Layout Front
- *
- * E S K I S T L F Ü N F
- * Z E H N Z W A N Z I G
- * D R E I V I E R T E L
- * N A C H A P P Y V O R
- * H A L B I R T H D A Y
- * D R Z W Ö L F Ü N F X
- * Z E H N E U N D R E I
- * Z W E I N S I E B E N
- * E L F V I E R A C H T
- * S E C H S I U H R Y E
+ *           Layout Front
+ *                COL
+ *       X 9 8 7 6 5 4 3 2 1 0
+ * ROW + - - - - - - - - - - -
+ *  0  | E S K I S T L F Ü N F
+ *  1  | Z E H N Z W A N Z I G
+ *  2  | D R E I V I E R T E L
+ *  3  | N A C H A P P Y V O R
+ *  4  | H A L B I R T H D A Y
+ *  5  | D R Z W Ö L F Ü N F X
+ *  6  | Z E H N E U N D R E I
+ *  7  | Z W E I N S I E B E N
+ *  8  | E L F V I E R A C H T
+ *  9  | S E C H S I U H R Y E
  *
  */
 
@@ -34,210 +36,109 @@ public:
         switch (word) {
 
         case FrontWord::es_ist:
-            // Es
-            setFrontMatrixPixel(0);
-            setFrontMatrixPixel(1);
-
-            // Ist
-            setFrontMatrixPixel(3);
-            setFrontMatrixPixel(4);
-            setFrontMatrixPixel(5);
+            setFrontMatrixWord(0, 9, 10);
+            setFrontMatrixWord(0, 5, 7);
             break;
 
         case FrontWord::nach:
         case FrontWord::v_nach:
-            setFrontMatrixPixel(43);
-            setFrontMatrixPixel(42);
-            setFrontMatrixPixel(41);
-            setFrontMatrixPixel(40);
+            setFrontMatrixWord(3, 7, 10);
             break;
 
         case FrontWord::vor:
         case FrontWord::v_vor:
-            setFrontMatrixPixel(33);
-            setFrontMatrixPixel(34);
-            setFrontMatrixPixel(35);
+            setFrontMatrixWord(3, 0, 2);
             break;
 
         case FrontWord::viertel:
-            setFrontMatrixPixel(32);
-            setFrontMatrixPixel(31);
-            setFrontMatrixPixel(30);
-            setFrontMatrixPixel(29);
-            setFrontMatrixPixel(28);
-            setFrontMatrixPixel(27);
-            setFrontMatrixPixel(26);
+            setFrontMatrixWord(2, 0, 6);
             break;
 
         case FrontWord::dreiviertel:
-            setFrontMatrixPixel(32);
-            setFrontMatrixPixel(31);
-            setFrontMatrixPixel(30);
-            setFrontMatrixPixel(29);
-            setFrontMatrixPixel(28);
-            setFrontMatrixPixel(27);
-            setFrontMatrixPixel(26);
-            setFrontMatrixPixel(25);
-            setFrontMatrixPixel(24);
-            setFrontMatrixPixel(23);
-            setFrontMatrixPixel(22);
+            setFrontMatrixWord(2, 0, 10);
             break;
 
         case FrontWord::fuenf:
-            setFrontMatrixPixel(7);
-            setFrontMatrixPixel(8);
-            setFrontMatrixPixel(9);
-            setFrontMatrixPixel(10);
+            setFrontMatrixWord(0, 0, 3);
             break;
 
         case FrontWord::zehn:
-            setFrontMatrixPixel(21);
-            setFrontMatrixPixel(20);
-            setFrontMatrixPixel(19);
-            setFrontMatrixPixel(18);
+            setFrontMatrixWord(1, 7, 10);
             break;
 
         case FrontWord::zwanzig:
-            setFrontMatrixPixel(17);
-            setFrontMatrixPixel(16);
-            setFrontMatrixPixel(15);
-            setFrontMatrixPixel(14);
-            setFrontMatrixPixel(13);
-            setFrontMatrixPixel(12);
-            setFrontMatrixPixel(11);
+            setFrontMatrixWord(1, 0, 6);
             break;
 
         case FrontWord::halb:
-            setFrontMatrixPixel(44);
-            setFrontMatrixPixel(45);
-            setFrontMatrixPixel(46);
-            setFrontMatrixPixel(47);
+            setFrontMatrixWord(4, 7, 10);
             break;
 
         case FrontWord::eins:
-            setFrontMatrixPixel(85);
-            setFrontMatrixPixel(84);
-            setFrontMatrixPixel(83);
-            setFrontMatrixPixel(82);
+            setFrontMatrixWord(7, 5, 8);
             break;
 
         case FrontWord::uhr:
-            setFrontMatrixPixel(101);
-            setFrontMatrixPixel(102);
-            setFrontMatrixPixel(103);
+            setFrontMatrixWord(9, 2, 4);
             break;
 
         case FrontWord::happy_birthday:
             // happy
-            setFrontMatrixPixel(40);
-            setFrontMatrixPixel(39);
-            setFrontMatrixPixel(38);
-            setFrontMatrixPixel(37);
-            setFrontMatrixPixel(36);
-
+            setFrontMatrixWord(3, 3, 7);
             // happy
-            setFrontMatrixPixel(47);
-            setFrontMatrixPixel(48);
-            setFrontMatrixPixel(49);
-            setFrontMatrixPixel(50);
-            setFrontMatrixPixel(51);
-            setFrontMatrixPixel(52);
-            setFrontMatrixPixel(53);
-            setFrontMatrixPixel(54);
+            setFrontMatrixWord(4, 0, 7);
             break;
 
         case FrontWord::h_ein:
-            setFrontMatrixPixel(85);
-            setFrontMatrixPixel(84);
-            setFrontMatrixPixel(83);
+            setFrontMatrixWord(7, 6, 8);
             break;
 
         case FrontWord::h_zwei:
-            setFrontMatrixPixel(87);
-            setFrontMatrixPixel(86);
-            setFrontMatrixPixel(85);
-            setFrontMatrixPixel(84);
+            setFrontMatrixWord(7, 7, 10);
             break;
 
         case FrontWord::h_drei:
-            setFrontMatrixPixel(73);
-            setFrontMatrixPixel(74);
-            setFrontMatrixPixel(75);
-            setFrontMatrixPixel(76);
+            setFrontMatrixWord(6, 0, 3);
             break;
 
         case FrontWord::h_vier:
-            setFrontMatrixPixel(91);
-            setFrontMatrixPixel(92);
-            setFrontMatrixPixel(93);
-            setFrontMatrixPixel(94);
+            setFrontMatrixWord(8, 4, 7);
             break;
 
         case FrontWord::h_fuenf:
-            setFrontMatrixPixel(59);
-            setFrontMatrixPixel(58);
-            setFrontMatrixPixel(57);
-            setFrontMatrixPixel(56);
+            setFrontMatrixWord(5, 1, 4);
             break;
 
         case FrontWord::h_sechs:
-            setFrontMatrixPixel(109);
-            setFrontMatrixPixel(108);
-            setFrontMatrixPixel(107);
-            setFrontMatrixPixel(106);
-            setFrontMatrixPixel(105);
+            setFrontMatrixWord(9, 6, 10);
             break;
 
         case FrontWord::h_sieben:
-            setFrontMatrixPixel(82);
-            setFrontMatrixPixel(81);
-            setFrontMatrixPixel(80);
-            setFrontMatrixPixel(79);
-            setFrontMatrixPixel(78);
-            setFrontMatrixPixel(77);
+            setFrontMatrixWord(7, 0, 5);
             break;
 
         case FrontWord::h_acht:
-            setFrontMatrixPixel(95);
-            setFrontMatrixPixel(96);
-            setFrontMatrixPixel(97);
-            setFrontMatrixPixel(98);
+            setFrontMatrixWord(8, 0, 3);
             break;
 
         case FrontWord::h_neun:
-            setFrontMatrixPixel(69);
-            setFrontMatrixPixel(70);
-            setFrontMatrixPixel(71);
-            setFrontMatrixPixel(72);
+            setFrontMatrixWord(6, 4, 7);
             break;
 
         case FrontWord::h_zehn:
-            setFrontMatrixPixel(66);
-            setFrontMatrixPixel(67);
-            setFrontMatrixPixel(68);
-            setFrontMatrixPixel(69);
+            setFrontMatrixWord(6, 7, 10);
             break;
 
         case FrontWord::h_elf:
-            setFrontMatrixPixel(88);
-            setFrontMatrixPixel(89);
-            setFrontMatrixPixel(90);
+            setFrontMatrixWord(8, 8, 10);
             break;
 
         case FrontWord::h_zwoelf:
-            setFrontMatrixPixel(63);
-            setFrontMatrixPixel(62);
-            setFrontMatrixPixel(61);
-            setFrontMatrixPixel(60);
-            setFrontMatrixPixel(59);
+            setFrontMatrixWord(5, 4, 8);
             break;
 
         case FrontWord::h_droelf:
-            setFrontMatrixPixel(65);
-            setFrontMatrixPixel(64);
-            setFrontMatrixPixel(61);
-            setFrontMatrixPixel(60);
-            setFrontMatrixPixel(59);
+            setFrontMatrixWord(5, 4, 8);
             break;
 
         default:

--- a/include/Uhrtypes/DE10x11.hpp
+++ b/include/Uhrtypes/DE10x11.hpp
@@ -3,18 +3,20 @@
 #include "Uhrtype.hpp"
 
 /*
- * Layout Front
- *
- * E S K I S T R F Ü N F
- * Z E H N Z W A N Z I G
- * D R E I V I E R T E L
- * T G N A C H V O R U M
- * H A L B G Z W Ö L F J
- * Z W E I N S I E B E N
- * K D R E I R H F Ü N F
- * E L F N E U N V I E R
- * N A C H T Z E H N B X
- * U S E C H S F U H R Y
+ *           Layout Front
+ *                COL
+ *       X 9 8 7 6 5 4 3 2 1 0
+ * ROW + - - - - - - - - - - -
+ *  0  | E S K I S T R F Ü N F
+ *  1  | Z E H N Z W A N Z I G
+ *  2  | D R E I V I E R T E L
+ *  3  | T G N A C H V O R U M
+ *  4  | H A L B G Z W Ö L F J
+ *  5  | Z W E I N S I E B E N
+ *  6  | K D R E I R H F Ü N F
+ *  7  | E L F N E U N V I E R
+ *  8  | N A C H T Z E H N B X
+ *  9  | U S E C H S F U H R Y
  */
 
 class De10x11_t : public iUhrType {
@@ -33,231 +35,102 @@ public:
         switch (word) {
 
         case FrontWord::es_ist:
-            // Es
-            setFrontMatrixPixel(0);
-            setFrontMatrixPixel(1);
-
-            // Ist
-            setFrontMatrixPixel(3);
-            setFrontMatrixPixel(4);
-            setFrontMatrixPixel(5);
+            setFrontMatrixWord(0, 9, 10);
+            setFrontMatrixWord(0, 5, 7);
             break;
-
-            //------------------------------------------------------------------------------
 
         case FrontWord::nach:
         case FrontWord::v_nach:
-            setFrontMatrixPixel(38);
-            setFrontMatrixPixel(39);
-            setFrontMatrixPixel(40);
-            setFrontMatrixPixel(41);
+            setFrontMatrixWord(3, 5, 8);
             break;
-
-            //------------------------------------------------------------------------------
 
         case FrontWord::vor:
         case FrontWord::v_vor:
-            setFrontMatrixPixel(35);
-            setFrontMatrixPixel(36);
-            setFrontMatrixPixel(37);
+            setFrontMatrixWord(3, 2, 4);
             break;
-            //------------------------------------------------------------------------------
 
         case FrontWord::viertel:
-            setFrontMatrixPixel(26);
-            setFrontMatrixPixel(27);
-            setFrontMatrixPixel(28);
-            setFrontMatrixPixel(29);
-            setFrontMatrixPixel(30);
-            setFrontMatrixPixel(31);
-            setFrontMatrixPixel(32);
+            setFrontMatrixWord(2, 0, 6);
             break;
-
-            //------------------------------------------------------------------------------
 
         case FrontWord::dreiviertel:
-            setFrontMatrixPixel(22);
-            setFrontMatrixPixel(23);
-            setFrontMatrixPixel(24);
-            setFrontMatrixPixel(25);
-            setFrontMatrixPixel(26);
-            setFrontMatrixPixel(27);
-            setFrontMatrixPixel(28);
-            setFrontMatrixPixel(29);
-            setFrontMatrixPixel(30);
-            setFrontMatrixPixel(31);
-            setFrontMatrixPixel(32);
+            setFrontMatrixWord(2, 0, 10);
             break;
-
-            //------------------------------------------------------------------------------
 
         case FrontWord::fuenf:
-            setFrontMatrixPixel(7);
-            setFrontMatrixPixel(8);
-            setFrontMatrixPixel(9);
-            setFrontMatrixPixel(10);
+            setFrontMatrixWord(0, 0, 3);
             break;
-
-            //------------------------------------------------------------------------------
 
         case FrontWord::zehn:
-            setFrontMatrixPixel(18);
-            setFrontMatrixPixel(19);
-            setFrontMatrixPixel(20);
-            setFrontMatrixPixel(21);
+            setFrontMatrixWord(1, 7, 10);
             break;
 
-            //------------------------------------------------------------------------------
         case FrontWord::zwanzig:
-            setFrontMatrixPixel(11);
-            setFrontMatrixPixel(12);
-            setFrontMatrixPixel(13);
-            setFrontMatrixPixel(14);
-            setFrontMatrixPixel(15);
-            setFrontMatrixPixel(16);
-            setFrontMatrixPixel(17);
+            setFrontMatrixWord(1, 0, 6);
             break;
-
-            //------------------------------------------------------------------------------
 
         case FrontWord::halb:
-            setFrontMatrixPixel(44);
-            setFrontMatrixPixel(45);
-            setFrontMatrixPixel(46);
-            setFrontMatrixPixel(47);
+            setFrontMatrixWord(4, 7, 10);
             break;
-
-            //------------------------------------------------------------------------------
 
         case FrontWord::eins:
-            setFrontMatrixPixel(60);
-            setFrontMatrixPixel(61);
-            setFrontMatrixPixel(62);
-            setFrontMatrixPixel(63);
+            setFrontMatrixWord(5, 5, 8);
             break;
-
-            //------------------------------------------------------------------------------
 
         case FrontWord::uhr:
-            setFrontMatrixPixel(100);
-            setFrontMatrixPixel(101);
-            setFrontMatrixPixel(102);
+            setFrontMatrixWord(9, 1, 3);
             break;
-
-            //------------------------------------------------------------------------------
 
         case FrontWord::h_ein:
-            setFrontMatrixPixel(61);
-            setFrontMatrixPixel(62);
-            setFrontMatrixPixel(63);
+            setFrontMatrixWord(5, 6, 8);
             break;
-
-            //------------------------------------------------------------------------------
 
         case FrontWord::h_zwei:
-            setFrontMatrixPixel(62);
-            setFrontMatrixPixel(63);
-            setFrontMatrixPixel(64);
-            setFrontMatrixPixel(65);
+            setFrontMatrixWord(5, 7, 10);
             break;
-
-            //------------------------------------------------------------------------------
 
         case FrontWord::h_drei:
-            setFrontMatrixPixel(67);
-            setFrontMatrixPixel(68);
-            setFrontMatrixPixel(69);
-            setFrontMatrixPixel(70);
+            setFrontMatrixWord(6, 6, 9);
             break;
-
-            //------------------------------------------------------------------------------
 
         case FrontWord::h_vier:
-            setFrontMatrixPixel(77);
-            setFrontMatrixPixel(78);
-            setFrontMatrixPixel(79);
-            setFrontMatrixPixel(80);
+            setFrontMatrixWord(7, 0, 3);
             break;
-
-            //------------------------------------------------------------------------------
 
         case FrontWord::h_fuenf:
-            setFrontMatrixPixel(73);
-            setFrontMatrixPixel(74);
-            setFrontMatrixPixel(75);
-            setFrontMatrixPixel(76);
+            setFrontMatrixWord(6, 0, 3);
             break;
-
-            //------------------------------------------------------------------------------
 
         case FrontWord::h_sechs:
-            setFrontMatrixPixel(104);
-            setFrontMatrixPixel(105);
-            setFrontMatrixPixel(106);
-            setFrontMatrixPixel(107);
-            setFrontMatrixPixel(108);
+            setFrontMatrixWord(9, 5, 9);
             break;
-
-            //------------------------------------------------------------------------------
 
         case FrontWord::h_sieben:
-            setFrontMatrixPixel(55);
-            setFrontMatrixPixel(56);
-            setFrontMatrixPixel(57);
-            setFrontMatrixPixel(58);
-            setFrontMatrixPixel(59);
-            setFrontMatrixPixel(60);
+            setFrontMatrixWord(5, 0, 5);
             break;
-
-            //------------------------------------------------------------------------------
 
         case FrontWord::h_acht:
-            setFrontMatrixPixel(89);
-            setFrontMatrixPixel(90);
-            setFrontMatrixPixel(91);
-            setFrontMatrixPixel(92);
+            setFrontMatrixWord(8, 6, 9);
             break;
-
-            //------------------------------------------------------------------------------
 
         case FrontWord::h_neun:
-            setFrontMatrixPixel(81);
-            setFrontMatrixPixel(82);
-            setFrontMatrixPixel(83);
-            setFrontMatrixPixel(84);
+            setFrontMatrixWord(7, 4, 7);
             break;
-
-            //------------------------------------------------------------------------------
 
         case FrontWord::h_zehn:
-            setFrontMatrixPixel(93);
-            setFrontMatrixPixel(94);
-            setFrontMatrixPixel(95);
-            setFrontMatrixPixel(96);
+            setFrontMatrixWord(8, 2, 5);
             break;
-
-            //------------------------------------------------------------------------------
 
         case FrontWord::h_elf:
-            setFrontMatrixPixel(85);
-            setFrontMatrixPixel(86);
-            setFrontMatrixPixel(87);
+            setFrontMatrixWord(7, 8, 10);
             break;
 
-            //------------------------------------------------------------------------------
-
         case FrontWord::h_zwoelf:
-
-            setFrontMatrixPixel(49);
-            setFrontMatrixPixel(50);
-            setFrontMatrixPixel(51);
-            setFrontMatrixPixel(52);
-            setFrontMatrixPixel(53);
+            setFrontMatrixWord(4, 1, 5);
             break;
 
         default:
             break;
-            //------------------------------------------------------------------------------
         };
     };
 };

--- a/include/Uhrtypes/DE10x11.nero.hpp
+++ b/include/Uhrtypes/DE10x11.nero.hpp
@@ -3,18 +3,20 @@
 #include "Uhrtype.hpp"
 
 /*
- * Layout Front
- *
- * E S J I S T L F Ü N F
- * Z E H N Z W A N Z I G
- * D R E I V I E R T E L
- * T F N A C H V O R J M
- * H A L B X Z W Ö L F T
- * Z W E I N S I E B E N
- * L D R E I C I F Ü N F
- * E L F N E U N V I E R
- * U A C H T Z E H N S I
- * C S E C H S T L U H R
+ *           Layout Front
+ *                COL
+ *       X 9 8 7 6 5 4 3 2 1 0
+ * ROW + - - - - - - - - - - -
+ *  0  | E S J I S T L F Ü N F
+ *  1  | Z E H N Z W A N Z I G
+ *  2  | D R E I V I E R T E L
+ *  3  | T F N A C H V O R J M
+ *  4  | H A L B X Z W Ö L F T
+ *  5  | Z W E I N S I E B E N
+ *  6  | L D R E I C I F Ü N F
+ *  7  | E L F N E U N V I E R
+ *  8  | U A C H T Z E H N S I
+ *  9  | C S E C H S T L U H R
  */
 
 class De10x11Nero_t : public iUhrType {
@@ -33,184 +35,98 @@ public:
         switch (word) {
 
         case FrontWord::es_ist:
-            // Es
-            setFrontMatrixPixel(0);
-            setFrontMatrixPixel(1);
-
-            // Ist
-            setFrontMatrixPixel(3);
-            setFrontMatrixPixel(4);
-            setFrontMatrixPixel(5);
+            setFrontMatrixWord(0, 9, 10);
+            setFrontMatrixWord(0, 5, 7);
             break;
 
         case FrontWord::nach:
         case FrontWord::v_nach:
-            setFrontMatrixPixel(38);
-            setFrontMatrixPixel(39);
-            setFrontMatrixPixel(40);
-            setFrontMatrixPixel(41);
+            setFrontMatrixWord(3, 5, 8);
             break;
 
         case FrontWord::vor:
         case FrontWord::v_vor:
-            setFrontMatrixPixel(35);
-            setFrontMatrixPixel(36);
-            setFrontMatrixPixel(37);
+            setFrontMatrixWord(3, 2, 4);
             break;
 
         case FrontWord::viertel:
-            setFrontMatrixPixel(26);
-            setFrontMatrixPixel(27);
-            setFrontMatrixPixel(28);
-            setFrontMatrixPixel(29);
-            setFrontMatrixPixel(30);
-            setFrontMatrixPixel(31);
-            setFrontMatrixPixel(32);
+            setFrontMatrixWord(2, 0, 6);
             break;
 
         case FrontWord::dreiviertel:
-            setFrontMatrixPixel(22);
-            setFrontMatrixPixel(23);
-            setFrontMatrixPixel(24);
-            setFrontMatrixPixel(25);
-            setFrontMatrixPixel(26);
-            setFrontMatrixPixel(27);
-            setFrontMatrixPixel(28);
-            setFrontMatrixPixel(29);
-            setFrontMatrixPixel(30);
-            setFrontMatrixPixel(31);
-            setFrontMatrixPixel(32);
+            setFrontMatrixWord(2, 0, 10);
             break;
 
         case FrontWord::fuenf:
-            setFrontMatrixPixel(7);
-            setFrontMatrixPixel(8);
-            setFrontMatrixPixel(9);
-            setFrontMatrixPixel(10);
+            setFrontMatrixWord(0, 0, 3);
             break;
 
         case FrontWord::zehn:
-            setFrontMatrixPixel(18);
-            setFrontMatrixPixel(19);
-            setFrontMatrixPixel(20);
-            setFrontMatrixPixel(21);
+            setFrontMatrixWord(1, 7, 10);
             break;
 
         case FrontWord::zwanzig:
-            setFrontMatrixPixel(11);
-            setFrontMatrixPixel(12);
-            setFrontMatrixPixel(13);
-            setFrontMatrixPixel(14);
-            setFrontMatrixPixel(15);
-            setFrontMatrixPixel(16);
-            setFrontMatrixPixel(17);
+            setFrontMatrixWord(1, 0, 6);
             break;
 
         case FrontWord::halb:
-            setFrontMatrixPixel(44);
-            setFrontMatrixPixel(45);
-            setFrontMatrixPixel(46);
-            setFrontMatrixPixel(47);
+            setFrontMatrixWord(4, 7, 10);
             break;
 
         case FrontWord::eins:
-            setFrontMatrixPixel(60);
-            setFrontMatrixPixel(61);
-            setFrontMatrixPixel(62);
-            setFrontMatrixPixel(63);
+            setFrontMatrixWord(5, 5, 8);
             break;
 
         case FrontWord::uhr:
-            setFrontMatrixPixel(99);
-            setFrontMatrixPixel(100);
-            setFrontMatrixPixel(101);
+            setFrontMatrixWord(9, 0, 2);
             break;
 
         case FrontWord::h_ein:
-            setFrontMatrixPixel(61);
-            setFrontMatrixPixel(62);
-            setFrontMatrixPixel(63);
+            setFrontMatrixWord(5, 6, 8);
             break;
 
         case FrontWord::h_zwei:
-            setFrontMatrixPixel(62);
-            setFrontMatrixPixel(63);
-            setFrontMatrixPixel(64);
-            setFrontMatrixPixel(65);
+            setFrontMatrixWord(5, 7, 10);
             break;
 
         case FrontWord::h_drei:
-            setFrontMatrixPixel(67);
-            setFrontMatrixPixel(68);
-            setFrontMatrixPixel(69);
-            setFrontMatrixPixel(70);
+            setFrontMatrixWord(6, 6, 9);
             break;
 
         case FrontWord::h_vier:
-            setFrontMatrixPixel(77);
-            setFrontMatrixPixel(78);
-            setFrontMatrixPixel(79);
-            setFrontMatrixPixel(80);
+            setFrontMatrixWord(7, 0, 3);
             break;
 
         case FrontWord::h_fuenf:
-            setFrontMatrixPixel(73);
-            setFrontMatrixPixel(74);
-            setFrontMatrixPixel(75);
-            setFrontMatrixPixel(76);
+            setFrontMatrixWord(6, 0, 3);
             break;
 
         case FrontWord::h_sechs:
-            setFrontMatrixPixel(104);
-            setFrontMatrixPixel(105);
-            setFrontMatrixPixel(106);
-            setFrontMatrixPixel(107);
-            setFrontMatrixPixel(108);
+            setFrontMatrixWord(9, 5, 9);
             break;
 
         case FrontWord::h_sieben:
-            setFrontMatrixPixel(55);
-            setFrontMatrixPixel(56);
-            setFrontMatrixPixel(57);
-            setFrontMatrixPixel(58);
-            setFrontMatrixPixel(59);
-            setFrontMatrixPixel(60);
+            setFrontMatrixWord(5, 0, 5);
             break;
 
         case FrontWord::h_acht:
-            setFrontMatrixPixel(89);
-            setFrontMatrixPixel(90);
-            setFrontMatrixPixel(91);
-            setFrontMatrixPixel(92);
+            setFrontMatrixWord(8, 6, 9);
             break;
 
         case FrontWord::h_neun:
-            setFrontMatrixPixel(81);
-            setFrontMatrixPixel(82);
-            setFrontMatrixPixel(83);
-            setFrontMatrixPixel(84);
+            setFrontMatrixWord(7, 4, 7);
             break;
 
         case FrontWord::h_zehn:
-            setFrontMatrixPixel(93);
-            setFrontMatrixPixel(94);
-            setFrontMatrixPixel(95);
-            setFrontMatrixPixel(96);
+            setFrontMatrixWord(8, 2, 5);
             break;
 
         case FrontWord::h_elf:
-            setFrontMatrixPixel(85);
-            setFrontMatrixPixel(86);
-            setFrontMatrixPixel(87);
+            setFrontMatrixWord(7, 8, 10);
             break;
 
         case FrontWord::h_zwoelf:
-
-            setFrontMatrixPixel(49);
-            setFrontMatrixPixel(50);
-            setFrontMatrixPixel(51);
-            setFrontMatrixPixel(52);
-            setFrontMatrixPixel(53);
+            setFrontMatrixWord(4, 1, 5);
             break;
 
         default:

--- a/include/Uhrtypes/DE10x11.vertical.hpp
+++ b/include/Uhrtypes/DE10x11.vertical.hpp
@@ -1,278 +1,48 @@
 #pragma once
 
-#include "Uhrtype.hpp"
+#include "DE10x11.2Clock.hpp"
 
 /*
- * Vertical Layout Front
- * Minutes 110 111 112 113
- *
- * E S K I S T A F Ü N F    009 010 029 030 049 050 069 070 089 090 109
- * Z E H N Z W A N Z I G    008 011 028 031 048 051 068 071 088 091 108
- * D R E I V I E R T E L    007 012 027 032 047 052 067 072 087 092 107
- * V O R F U N K N A C H    006 013 026 033 046 053 066 073 086 093 106
- * H A L B A E L F Ü N F    005 014 025 034 045 054 065 074 085 094 105
- * E I N S X A M Z W E I    004 015 024 035 044 055 064 075 084 095 104
- * D R E I A U J V I E R    003 016 023 036 043 056 063 076 083 096 103
- * S E C H S N L A C H T    002 017 022 037 042 057 062 077 082 097 102
- * S I E B E N Z W Ö L F    001 018 021 038 041 058 061 078 081 098 101
- * Z E H N E U N K U H R    000 019 020 039 040 059 060 079 080 099 100
+ *           Layout Front
+ *                COL
+ *       X 9 8 7 6 5 4 3 2 1 0              Minutes 110 111 112 113
+ * ROW + - - - - - - - - - - -
+ *  0  | E S K I S T A F Ü N F    009 010 029 030 049 050 069 070 089 090 109
+ *  1  | Z E H N Z W A N Z I G    008 011 028 031 048 051 068 071 088 091 108
+ *  2  | D R E I V I E R T E L    007 012 027 032 047 052 067 072 087 092 107
+ *  3  | V O R F U N K N A C H    006 013 026 033 046 053 066 073 086 093 106
+ *  4  | H A L B A E L F Ü N F    005 014 025 034 045 054 065 074 085 094 105
+ *  5  | E I N S X A M Z W E I    004 015 024 035 044 055 064 075 084 095 104
+ *  6  | D R E I A U J V I E R    003 016 023 036 043 056 063 076 083 096 103
+ *  7  | S E C H S N L A C H T    002 017 022 037 042 057 062 077 082 097 102
+ *  8  | S I E B E N Z W Ö L F    001 018 021 038 041 058 061 078 081 098 101
+ *  9  | Z E H N E U N K U H R    000 019 020 039 040 059 060 079 080 099 100
  */
 
-class De10x11Vertical_t : public iUhrType {
+class De10x11Vertical_t : public De10x11Clock_t {
 public:
-    //------------------------------------------------------------------------------
+    virtual const uint16_t getFrontMatrixIndex(uint8_t row,
+                                               uint8_t col) override {
+        uint8_t newColsWordMatrix = colsWordMatrix();
+        uint16_t numPixelsWordMatrix = rowsWordMatrix() * colsWordMatrix();
 
-    virtual LanguageAbbreviation usedLang() override {
-        return LanguageAbbreviation::DE;
-    };
+        if (G.buildTypeDef == BuildTypeDef::DoubleResM1) {
+            newColsWordMatrix = 2 * colsWordMatrix() - 1;
+            numPixelsWordMatrix = rowsWordMatrix() * newColsWordMatrix;
+            col *= 2;
+        }
 
-    //------------------------------------------------------------------------------
-
-    virtual const bool hasDreiviertel() override { return true; }
-
-    //------------------------------------------------------------------------------
-
-    virtual const void getFrontMatrixColRow(uint8_t &row, uint8_t &col,
-                                            const uint16 index) {
-        row = index % rowsWordMatrix();
-        col = colsWordMatrix() - 1 - (index / rowsWordMatrix());
         if (col % 2 == 0) {
             row = rowsWordMatrix() - 1 - row;
         }
-    };
+        uint16_t returnValue =
+            row + rowsWordMatrix() * (newColsWordMatrix - 1 - col);
 
-    //------------------------------------------------------------------------------
-
-    void show(FrontWord word) override {
-        switch (word) {
-
-        case FrontWord::es_ist:
-            // Es
-            setFrontMatrixPixel(9);
-            setFrontMatrixPixel(10);
-
-            // Ist
-            setFrontMatrixPixel(30);
-            setFrontMatrixPixel(49);
-            setFrontMatrixPixel(50);
-            break;
-
-            //------------------------------------------------------------------------------
-
-        case FrontWord::nach:
-        case FrontWord::v_nach:
-            setFrontMatrixPixel(73);
-            setFrontMatrixPixel(86);
-            setFrontMatrixPixel(93);
-            setFrontMatrixPixel(106);
-            break;
-
-            //------------------------------------------------------------------------------
-
-        case FrontWord::vor:
-        case FrontWord::v_vor:
-            setFrontMatrixPixel(6);
-            setFrontMatrixPixel(13);
-            setFrontMatrixPixel(26);
-            break;
-            //------------------------------------------------------------------------------
-
-        case FrontWord::viertel:
-            setFrontMatrixPixel(47);
-            setFrontMatrixPixel(52);
-            setFrontMatrixPixel(67);
-            setFrontMatrixPixel(72);
-            setFrontMatrixPixel(87);
-            setFrontMatrixPixel(92);
-            setFrontMatrixPixel(107);
-            break;
-
-            //------------------------------------------------------------------------------
-
-        case FrontWord::dreiviertel:
-            setFrontMatrixPixel(07);
-            setFrontMatrixPixel(12);
-            setFrontMatrixPixel(27);
-            setFrontMatrixPixel(32);
-            setFrontMatrixPixel(47);
-            setFrontMatrixPixel(52);
-            setFrontMatrixPixel(67);
-            setFrontMatrixPixel(72);
-            setFrontMatrixPixel(87);
-            setFrontMatrixPixel(92);
-            setFrontMatrixPixel(107);
-            break;
-
-            //------------------------------------------------------------------------------
-
-        case FrontWord::fuenf:
-            setFrontMatrixPixel(70);
-            setFrontMatrixPixel(89);
-            setFrontMatrixPixel(90);
-            setFrontMatrixPixel(109);
-            break;
-
-            //------------------------------------------------------------------------------
-
-        case FrontWord::zehn:
-            setFrontMatrixPixel(8);
-            setFrontMatrixPixel(11);
-            setFrontMatrixPixel(28);
-            setFrontMatrixPixel(31);
-            break;
-
-            //------------------------------------------------------------------------------
-        case FrontWord::zwanzig:
-            setFrontMatrixPixel(48);
-            setFrontMatrixPixel(51);
-            setFrontMatrixPixel(68);
-            setFrontMatrixPixel(71);
-            setFrontMatrixPixel(88);
-            setFrontMatrixPixel(91);
-            setFrontMatrixPixel(108);
-            break;
-
-            //------------------------------------------------------------------------------
-
-        case FrontWord::halb:
-            setFrontMatrixPixel(5);
-            setFrontMatrixPixel(14);
-            setFrontMatrixPixel(25);
-            setFrontMatrixPixel(34);
-            break;
-
-            //------------------------------------------------------------------------------
-
-        case FrontWord::eins:
-            setFrontMatrixPixel(4);
-            setFrontMatrixPixel(15);
-            setFrontMatrixPixel(24);
-            setFrontMatrixPixel(35);
-            break;
-
-            //------------------------------------------------------------------------------
-
-        case FrontWord::uhr:
-            setFrontMatrixPixel(80);
-            setFrontMatrixPixel(99);
-            setFrontMatrixPixel(100);
-            break;
-
-            //------------------------------------------------------------------------------
-
-        case FrontWord::h_ein:
-            setFrontMatrixPixel(4);
-            setFrontMatrixPixel(15);
-            setFrontMatrixPixel(24);
-            break;
-
-            //------------------------------------------------------------------------------
-
-        case FrontWord::h_zwei:
-            setFrontMatrixPixel(75);
-            setFrontMatrixPixel(84);
-            setFrontMatrixPixel(95);
-            setFrontMatrixPixel(104);
-            break;
-
-            //------------------------------------------------------------------------------
-
-        case FrontWord::h_drei:
-            setFrontMatrixPixel(3);
-            setFrontMatrixPixel(16);
-            setFrontMatrixPixel(23);
-            setFrontMatrixPixel(36);
-            break;
-
-            //------------------------------------------------------------------------------
-
-        case FrontWord::h_vier:
-            setFrontMatrixPixel(76);
-            setFrontMatrixPixel(83);
-            setFrontMatrixPixel(96);
-            setFrontMatrixPixel(103);
-            break;
-
-            //------------------------------------------------------------------------------
-
-        case FrontWord::h_fuenf:
-            setFrontMatrixPixel(74);
-            setFrontMatrixPixel(85);
-            setFrontMatrixPixel(94);
-            setFrontMatrixPixel(105);
-            break;
-
-            //------------------------------------------------------------------------------
-
-        case FrontWord::h_sechs:
-            setFrontMatrixPixel(2);
-            setFrontMatrixPixel(17);
-            setFrontMatrixPixel(22);
-            setFrontMatrixPixel(37);
-            setFrontMatrixPixel(42);
-            break;
-
-            //------------------------------------------------------------------------------
-
-        case FrontWord::h_sieben:
-            setFrontMatrixPixel(1);
-            setFrontMatrixPixel(18);
-            setFrontMatrixPixel(21);
-            setFrontMatrixPixel(38);
-            setFrontMatrixPixel(41);
-            setFrontMatrixPixel(58);
-            break;
-
-            //------------------------------------------------------------------------------
-
-        case FrontWord::h_acht:
-            setFrontMatrixPixel(77);
-            setFrontMatrixPixel(82);
-            setFrontMatrixPixel(97);
-            setFrontMatrixPixel(102);
-            break;
-
-            //------------------------------------------------------------------------------
-
-        case FrontWord::h_neun:
-            setFrontMatrixPixel(39);
-            setFrontMatrixPixel(40);
-            setFrontMatrixPixel(59);
-            setFrontMatrixPixel(60);
-            break;
-
-            //------------------------------------------------------------------------------
-
-        case FrontWord::h_zehn:
-            setFrontMatrixPixel(0);
-            setFrontMatrixPixel(19);
-            setFrontMatrixPixel(20);
-            setFrontMatrixPixel(39);
-            break;
-
-            //------------------------------------------------------------------------------
-
-        case FrontWord::h_elf:
-            setFrontMatrixPixel(54);
-            setFrontMatrixPixel(65);
-            setFrontMatrixPixel(74);
-            break;
-
-            //------------------------------------------------------------------------------
-
-        case FrontWord::h_zwoelf:
-
-            setFrontMatrixPixel(61);
-            setFrontMatrixPixel(78);
-            setFrontMatrixPixel(81);
-            setFrontMatrixPixel(98);
-            setFrontMatrixPixel(101);
-            break;
-
-        default:
-            break;
-            //------------------------------------------------------------------------------
-        };
+        if (returnValue > numPixelsWordMatrix) {
+            Serial.println(
+                "[ERROR] getFrontMatrixIndex() returnValue out of Bounds");
+        }
+        return returnValue;
     };
 };
 

--- a/include/Uhrtypes/DE10x11.vertical.hpp
+++ b/include/Uhrtypes/DE10x11.vertical.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "DE10x11.2Clock.hpp"
+#include "DE10x11.2clock.hpp"
 
 /*
  *           Layout Front

--- a/include/Uhrtypes/DE11x11.hpp
+++ b/include/Uhrtypes/DE11x11.hpp
@@ -3,20 +3,21 @@
 #include "Uhrtype.hpp"
 
 /*
- * Layout Front
- *
- * E S K I S T R F Ü N F
- * Z E H N Z W A N Z I G
- * D R E I V I E R T E L
- * T G N A C H V O R U M
- * H A L B G Z W Ö L F J
- * Z W E I N S I E B E N
- * K D R E I R H F Ü N F
- * E L F N E U N V I E R
- * N A C H T Z E H N B X
- * U S E C H S F U E R Y
- * W A S D F U N K U H R
- * + + + +
+ *           Layout Front
+ *                COL
+ *       X 9 8 7 6 5 4 3 2 1 0
+ * ROW + - - - - - - - - - - -
+ *  0  | E S K I S T R F Ü N F
+ *  1  | Z E H N Z W A N Z I G
+ *  2  | D R E I V I E R T E L
+ *  3  | T G N A C H V O R U M
+ *  4  | H A L B G Z W Ö L F J
+ *  5  | Z W E I N S I E B E N
+ *  6  | K D R E I R H F Ü N F
+ *  7  | E L F N E U N V I E R
+ *  8  | N A C H T Z E H N B X
+ *  9  | U S E C H S F U E R Y
+ *  X  | W A S D F U N K U H R
  */
 
 class De11x11_t : public iUhrType {
@@ -32,14 +33,20 @@ public:
 
         uint16_t numPixelsWordMatrix = rowsWordMatrix() * colsWordMatrix();
 
+        if (G.buildTypeDef == BuildTypeDef::DoubleResM1) {
+            numPixelsWordMatrix = rowsWordMatrix() * (colsWordMatrix() * 2 - 1);
+        }
+
         for (uint8_t i = 0; i < 4; i++) {
             switch (col) {
             case 0: // LEDs for "LED4x" minute display
-                returnArr[i] = numPixelsWordMatrix + i;
+                returnArr[i] = numPixelsWordMatrix - (7 - i);
                 break;
+
             case 1: // LEDs for "LED7x" minute display
-                returnArr[i] = numPixelsWordMatrix + (i * 2);
+                returnArr[i] = numPixelsWordMatrix - (7 - (i * 2));
                 break;
+
             case 2: // LEDs für "Corners" type minute display
                 returnArr[i] = 110 + i;
                 break;
@@ -64,189 +71,100 @@ public:
         switch (word) {
 
         case FrontWord::es_ist:
-            // Es
-            setFrontMatrixPixel(0);
-            setFrontMatrixPixel(1);
-
-            // Ist
-            setFrontMatrixPixel(3);
-            setFrontMatrixPixel(4);
-            setFrontMatrixPixel(5);
+            setFrontMatrixWord(0, 9, 10);
+            setFrontMatrixWord(0, 5, 7);
             break;
 
         case FrontWord::viertel:
-            setFrontMatrixPixel(26);
-            setFrontMatrixPixel(27);
-            setFrontMatrixPixel(28);
-            setFrontMatrixPixel(29);
-            setFrontMatrixPixel(30);
-            setFrontMatrixPixel(31);
-            setFrontMatrixPixel(32);
+            setFrontMatrixWord(2, 0, 6);
             break;
 
         case FrontWord::dreiviertel:
-            setFrontMatrixPixel(22);
-            setFrontMatrixPixel(23);
-            setFrontMatrixPixel(24);
-            setFrontMatrixPixel(25);
-            setFrontMatrixPixel(26);
-            setFrontMatrixPixel(27);
-            setFrontMatrixPixel(28);
-            setFrontMatrixPixel(29);
-            setFrontMatrixPixel(30);
-            setFrontMatrixPixel(31);
-            setFrontMatrixPixel(32);
+            setFrontMatrixWord(2, 0, 10);
             break;
 
         case FrontWord::fuenf:
-            setFrontMatrixPixel(7);
-            setFrontMatrixPixel(8);
-            setFrontMatrixPixel(9);
-            setFrontMatrixPixel(10);
+            setFrontMatrixWord(0, 0, 3);
             break;
 
         case FrontWord::zehn:
-            setFrontMatrixPixel(18);
-            setFrontMatrixPixel(19);
-            setFrontMatrixPixel(20);
-            setFrontMatrixPixel(21);
+            setFrontMatrixWord(1, 7, 10);
             break;
 
         case FrontWord::zwanzig:
-            setFrontMatrixPixel(11);
-            setFrontMatrixPixel(12);
-            setFrontMatrixPixel(13);
-            setFrontMatrixPixel(14);
-            setFrontMatrixPixel(15);
-            setFrontMatrixPixel(16);
-            setFrontMatrixPixel(17);
+            setFrontMatrixWord(1, 0, 6);
             break;
 
         case FrontWord::halb:
-            setFrontMatrixPixel(44);
-            setFrontMatrixPixel(45);
-            setFrontMatrixPixel(46);
-            setFrontMatrixPixel(47);
+            setFrontMatrixWord(4, 7, 10);
             break;
 
         case FrontWord::eins:
-            setFrontMatrixPixel(60);
-            setFrontMatrixPixel(61);
-            setFrontMatrixPixel(62);
-            setFrontMatrixPixel(63);
+            setFrontMatrixWord(5, 5, 8);
             break;
 
         case FrontWord::nach:
         case FrontWord::v_nach:
-            setFrontMatrixPixel(38);
-            setFrontMatrixPixel(39);
-            setFrontMatrixPixel(40);
-            setFrontMatrixPixel(41);
+            setFrontMatrixWord(3, 5, 8);
             break;
 
         case FrontWord::vor:
         case FrontWord::v_vor:
-            setFrontMatrixPixel(35);
-            setFrontMatrixPixel(36);
-            setFrontMatrixPixel(37);
-
+            setFrontMatrixWord(3, 2, 4);
         case FrontWord::uhr:
-            setFrontMatrixPixel(120);
-            setFrontMatrixPixel(119);
-            setFrontMatrixPixel(118);
+            setFrontMatrixWord(10, 0, 2);
             break;
 
         case FrontWord::h_ein:
-            setFrontMatrixPixel(61);
-            setFrontMatrixPixel(62);
-            setFrontMatrixPixel(63);
+            setFrontMatrixWord(5, 6, 8);
             break;
 
         case FrontWord::h_zwei:
-            setFrontMatrixPixel(62);
-            setFrontMatrixPixel(63);
-            setFrontMatrixPixel(64);
-            setFrontMatrixPixel(65);
+            setFrontMatrixWord(5, 7, 10);
             break;
 
         case FrontWord::h_drei:
-            setFrontMatrixPixel(67);
-            setFrontMatrixPixel(68);
-            setFrontMatrixPixel(69);
-            setFrontMatrixPixel(70);
+            setFrontMatrixWord(6, 6, 9);
             break;
 
         case FrontWord::h_vier:
-            setFrontMatrixPixel(77);
-            setFrontMatrixPixel(78);
-            setFrontMatrixPixel(79);
-            setFrontMatrixPixel(80);
+            setFrontMatrixWord(7, 0, 3);
             break;
 
         case FrontWord::h_fuenf:
-            setFrontMatrixPixel(73);
-            setFrontMatrixPixel(74);
-            setFrontMatrixPixel(75);
-            setFrontMatrixPixel(76);
+            setFrontMatrixWord(6, 0, 3);
             break;
 
         case FrontWord::h_sechs:
-            setFrontMatrixPixel(104);
-            setFrontMatrixPixel(105);
-            setFrontMatrixPixel(106);
-            setFrontMatrixPixel(107);
-            setFrontMatrixPixel(108);
+            setFrontMatrixWord(9, 5, 9);
             break;
 
         case FrontWord::h_sieben:
-            setFrontMatrixPixel(55);
-            setFrontMatrixPixel(56);
-            setFrontMatrixPixel(57);
-            setFrontMatrixPixel(58);
-            setFrontMatrixPixel(59);
-            setFrontMatrixPixel(60);
+            setFrontMatrixWord(5, 0, 5);
             break;
 
         case FrontWord::h_acht:
-            setFrontMatrixPixel(89);
-            setFrontMatrixPixel(90);
-            setFrontMatrixPixel(91);
-            setFrontMatrixPixel(92);
+            setFrontMatrixWord(8, 6, 9);
             break;
 
         case FrontWord::h_neun:
-            setFrontMatrixPixel(81);
-            setFrontMatrixPixel(82);
-            setFrontMatrixPixel(83);
-            setFrontMatrixPixel(84);
+            setFrontMatrixWord(7, 4, 7);
             break;
 
         case FrontWord::h_zehn:
-            setFrontMatrixPixel(93);
-            setFrontMatrixPixel(94);
-            setFrontMatrixPixel(95);
-            setFrontMatrixPixel(96);
+            setFrontMatrixWord(8, 2, 5);
             break;
 
         case FrontWord::h_elf:
-            setFrontMatrixPixel(85);
-            setFrontMatrixPixel(86);
-            setFrontMatrixPixel(87);
+            setFrontMatrixWord(7, 8, 10);
             break;
 
         case FrontWord::h_zwoelf:
-            setFrontMatrixPixel(49);
-            setFrontMatrixPixel(50);
-            setFrontMatrixPixel(51);
-            setFrontMatrixPixel(52);
-            setFrontMatrixPixel(53);
+            setFrontMatrixWord(4, 1, 5);
             break;
 
         case FrontWord::funk:
-            setFrontMatrixPixel(114);
-            setFrontMatrixPixel(115);
-            setFrontMatrixPixel(116);
-            setFrontMatrixPixel(117);
+            setFrontMatrixWord(10, 3, 6);
             break;
 
         default:

--- a/include/Uhrtypes/DE11x11.v2.hpp
+++ b/include/Uhrtypes/DE11x11.v2.hpp
@@ -3,20 +3,21 @@
 #include "DE11x11.hpp"
 
 /*
- * Layout Front
- *
- * E S K I S T A F Ü N F
- * Z E H N D A U V O R G
- * N A C H V I E R T E L
- * H A L B V O R N A C H
- * E I N S K U R Z W E I
- * D R E I A U J V I E R
- * F Ü N F T O S E C H S
- * S I E B E N L A C H T
- * A N E U N M H Z E H N
- * Z W Ö L F D T F E L F
- * W A S D F U N K U H R
- * + + + +
+ *           Layout Front
+ *                COL
+ *       X 9 8 7 6 5 4 3 2 1 0
+ * ROW + - - - - - - - - - - -
+ *  0  | E S K I S T A F Ü N F
+ *  1  | Z E H N D A U V O R G
+ *  2  | N A C H V I E R T E L
+ *  3  | H A L B V O R N A C H
+ *  4  | E I N S K U R Z W E I
+ *  5  | D R E I A U J V I E R
+ *  6  | F Ü N F T O S E C H S
+ *  7  | S I E B E N L A C H T
+ *  8  | A N E U N M H Z E H N
+ *  9  | Z W Ö L F D T F E L F
+ *  X  | W A S D F U N K U H R
  */
 
 class De11x11V2_t : public De11x11_t {
@@ -26,176 +27,101 @@ public:
 
         case FrontWord::es_ist:
             // Es
-            setFrontMatrixPixel(0);
-            setFrontMatrixPixel(1);
-
+            setFrontMatrixWord(0, 9, 10);
             // Ist
-            setFrontMatrixPixel(3);
-            setFrontMatrixPixel(4);
-            setFrontMatrixPixel(5);
+            setFrontMatrixWord(0, 5, 7);
             break;
 
         case FrontWord::nach:
-            setFrontMatrixPixel(22);
-            setFrontMatrixPixel(23);
-            setFrontMatrixPixel(24);
-            setFrontMatrixPixel(25);
+            setFrontMatrixWord(2, 7, 10);
             break;
 
         case FrontWord::vor:
-            setFrontMatrixPixel(12);
-            setFrontMatrixPixel(13);
-            setFrontMatrixPixel(14);
+            setFrontMatrixWord(1, 1, 3);
             break;
 
         case FrontWord::viertel:
-            setFrontMatrixPixel(26);
-            setFrontMatrixPixel(27);
-            setFrontMatrixPixel(28);
-            setFrontMatrixPixel(29);
-            setFrontMatrixPixel(30);
-            setFrontMatrixPixel(31);
-            setFrontMatrixPixel(32);
+            setFrontMatrixWord(2, 0, 6);
             break;
 
         case FrontWord::fuenf:
-            setFrontMatrixPixel(7);
-            setFrontMatrixPixel(8);
-            setFrontMatrixPixel(9);
-            setFrontMatrixPixel(10);
+            setFrontMatrixWord(0, 0, 3);
             break;
 
         case FrontWord::zehn:
-            setFrontMatrixPixel(18);
-            setFrontMatrixPixel(19);
-            setFrontMatrixPixel(20);
-            setFrontMatrixPixel(21);
+            setFrontMatrixWord(1, 7, 10);
             break;
 
         case FrontWord::halb:
-            setFrontMatrixPixel(43);
-            setFrontMatrixPixel(42);
-            setFrontMatrixPixel(41);
-            setFrontMatrixPixel(40);
+            setFrontMatrixWord(3, 7, 10);
             break;
 
         case FrontWord::eins:
-            setFrontMatrixPixel(44);
-            setFrontMatrixPixel(45);
-            setFrontMatrixPixel(46);
-            setFrontMatrixPixel(47);
+            setFrontMatrixWord(4, 7, 10);
             break;
 
         case FrontWord::uhr:
-            setFrontMatrixPixel(120);
-            setFrontMatrixPixel(119);
-            setFrontMatrixPixel(118);
+            setFrontMatrixWord(10, 0, 2);
             break;
 
         case FrontWord::v_nach:
-            setFrontMatrixPixel(36);
-            setFrontMatrixPixel(35);
-            setFrontMatrixPixel(34);
-            setFrontMatrixPixel(33);
+            setFrontMatrixWord(3, 0, 3);
             break;
 
         case FrontWord::v_vor:
-            setFrontMatrixPixel(39);
-            setFrontMatrixPixel(38);
-            setFrontMatrixPixel(37);
+            setFrontMatrixWord(3, 4, 6);
             break;
 
         case FrontWord::h_ein:
-            setFrontMatrixPixel(44);
-            setFrontMatrixPixel(45);
-            setFrontMatrixPixel(46);
+            setFrontMatrixWord(4, 8, 10);
             break;
 
         case FrontWord::h_zwei:
-            setFrontMatrixPixel(51);
-            setFrontMatrixPixel(52);
-            setFrontMatrixPixel(53);
-            setFrontMatrixPixel(54);
+            setFrontMatrixWord(4, 0, 3);
             break;
 
         case FrontWord::h_drei:
-            setFrontMatrixPixel(62);
-            setFrontMatrixPixel(63);
-            setFrontMatrixPixel(64);
-            setFrontMatrixPixel(65);
+            setFrontMatrixWord(5, 7, 10);
             break;
 
         case FrontWord::h_vier:
-            setFrontMatrixPixel(55);
-            setFrontMatrixPixel(56);
-            setFrontMatrixPixel(57);
-            setFrontMatrixPixel(58);
+            setFrontMatrixWord(5, 0, 3);
             break;
 
         case FrontWord::h_fuenf:
-            setFrontMatrixPixel(66);
-            setFrontMatrixPixel(67);
-            setFrontMatrixPixel(68);
-            setFrontMatrixPixel(69);
+            setFrontMatrixWord(6, 7, 10);
             break;
 
         case FrontWord::h_sechs:
-            setFrontMatrixPixel(72);
-            setFrontMatrixPixel(73);
-            setFrontMatrixPixel(74);
-            setFrontMatrixPixel(75);
-            setFrontMatrixPixel(76);
+            setFrontMatrixWord(6, 0, 4);
             break;
 
         case FrontWord::h_sieben:
-            setFrontMatrixPixel(87);
-            setFrontMatrixPixel(86);
-            setFrontMatrixPixel(85);
-            setFrontMatrixPixel(84);
-            setFrontMatrixPixel(83);
-            setFrontMatrixPixel(82);
+            setFrontMatrixWord(7, 5, 10);
             break;
 
         case FrontWord::h_acht:
-            setFrontMatrixPixel(77);
-            setFrontMatrixPixel(78);
-            setFrontMatrixPixel(79);
-            setFrontMatrixPixel(80);
+            setFrontMatrixWord(7, 0, 3);
             break;
 
         case FrontWord::h_neun:
-            setFrontMatrixPixel(89);
-            setFrontMatrixPixel(90);
-            setFrontMatrixPixel(91);
-            setFrontMatrixPixel(92);
+            setFrontMatrixWord(8, 6, 9);
             break;
 
         case FrontWord::h_zehn:
-            setFrontMatrixPixel(95);
-            setFrontMatrixPixel(96);
-            setFrontMatrixPixel(97);
-            setFrontMatrixPixel(98);
+            setFrontMatrixWord(8, 0, 3);
             break;
 
         case FrontWord::h_elf:
-            setFrontMatrixPixel(99);
-            setFrontMatrixPixel(100);
-            setFrontMatrixPixel(101);
+            setFrontMatrixWord(9, 0, 2);
             break;
 
         case FrontWord::h_zwoelf:
-            setFrontMatrixPixel(105);
-            setFrontMatrixPixel(106);
-            setFrontMatrixPixel(107);
-            setFrontMatrixPixel(108);
-            setFrontMatrixPixel(109);
+            setFrontMatrixWord(9, 6, 10);
             break;
 
         case FrontWord::funk:
-            setFrontMatrixPixel(114);
-            setFrontMatrixPixel(115);
-            setFrontMatrixPixel(116);
-            setFrontMatrixPixel(117);
+            setFrontMatrixWord(10, 3, 6);
             break;
 
         default:

--- a/include/Uhrtypes/DE16x18.hpp
+++ b/include/Uhrtypes/DE16x18.hpp
@@ -3,24 +3,26 @@
 #include "Uhrtype.hpp"
 
 /*
- * Layout Front
- *
- * E S A I S T O V I E R T E L E I N S
- * D R E I N E R S E C H S I E B E N E
- * E L F Ü N F N E U N V I E R A C H T
- * N U L L Z W E I N Z W Ö L F Z E H N
- * U N D O Z W A N Z I G V I E R Z I G
- * D R E I S S I G F Ü N F Z I G U H R
- * M I N U T E N I V O R U N D N A C H
- * E I N D R E I V I E R T E L H A L B
- * S I E B E N E U N U L L Z W E I N E
- * F Ü N F S E C H S N A C H T V I E R
- * D R E I N S U N D A E L F E Z E H N
- * Z W A N Z I G G R A D R E I S S I G
- * V I E R Z I G Z W Ö L F Ü N F Z I G
- * M I N U T E N U H R E F R Ü H V O R
- * A B E N D S M I T T E R N A C H T S
- * M O R G E N S W A R M M I T T A G S
+ *                  Layout Front
+ *                       COL
+ *       7 6 5 4 3 2 1 X 9 8 7 6 5 4 3 2 1 0
+ * ROW + - - - - - - - - - - - - - - - - - -
+ *  0  | E S A I S T O V I E R T E L E I N S
+ *  1  | D R E I N E R S E C H S I E B E N E
+ *  2  | E L F Ü N F N E U N V I E R A C H T
+ *  3  | N U L L Z W E I N Z W Ö L F Z E H N
+ *  4  | U N D O Z W A N Z I G V I E R Z I G
+ *  5  | D R E I S S I G F Ü N F Z I G U H R
+ *  6  | M I N U T E N I V O R U N D N A C H
+ *  7  | E I N D R E I V I E R T E L H A L B
+ *  8  | S I E B E N E U N U L L Z W E I N E
+ *  9  | F Ü N F S E C H S N A C H T V I E R
+ *  X  | D R E I N S U N D A E L F E Z E H N
+ *  1  | Z W A N Z I G G R A D R E I S S I G
+ *  2  | V I E R Z I G Z W Ö L F Ü N F Z I G
+ *  3  | M I N U T E N U H R E F R Ü H V O R
+ *  4  | A B E N D S M I T T E R N A C H T S
+ *  5  | M O R G E N S W A R M M I T T A G S
  *
  */
 
@@ -52,428 +54,219 @@ public:
         switch (word) {
 
         case FrontWord::m_eine:
-            setFrontMatrixPixel(33);
-            setFrontMatrixPixel(32);
-            setFrontMatrixPixel(31);
-            setFrontMatrixPixel(30); // eine minute nach
+            setFrontMatrixWord(1, 12, 15);
             break;
 
         case FrontWord::m_zwei:
-            setFrontMatrixPixel(67);
-            setFrontMatrixPixel(66);
-            setFrontMatrixPixel(65);
-            setFrontMatrixPixel(64); // zwei minuten nach
+            setFrontMatrixWord(3, 10, 13);
             break;
 
         case FrontWord::m_drei:
-            setFrontMatrixPixel(35);
-            setFrontMatrixPixel(34);
-            setFrontMatrixPixel(33);
-            setFrontMatrixPixel(32); // drei minuten nach
+            setFrontMatrixWord(1, 14, 17);
             break;
 
         case FrontWord::m_vier:
-            setFrontMatrixPixel(49);
-            setFrontMatrixPixel(48);
-            setFrontMatrixPixel(47);
-            setFrontMatrixPixel(46); // vier minuten nach
+            setFrontMatrixWord(2, 4, 7);
             break;
 
         case FrontWord::fuenf:
-            setFrontMatrixPixel(38);
-            setFrontMatrixPixel(39);
-            setFrontMatrixPixel(40);
-            setFrontMatrixPixel(41); // fünf minuten nach
+            setFrontMatrixWord(2, 12, 15);
             break;
 
         case FrontWord::m_sechs:
-            setFrontMatrixPixel(24);
-            setFrontMatrixPixel(25);
-            setFrontMatrixPixel(26);
-            setFrontMatrixPixel(27);
-            setFrontMatrixPixel(28); // sechs minuten nach
+            setFrontMatrixWord(1, 6, 10);
             break;
 
         case FrontWord::m_sieben:
-            setFrontMatrixPixel(19);
-            setFrontMatrixPixel(20);
-            setFrontMatrixPixel(21);
-            setFrontMatrixPixel(22);
-            setFrontMatrixPixel(23);
-            setFrontMatrixPixel(24); // sieben minuten nach
+            setFrontMatrixWord(1, 1, 6);
             break;
 
         case FrontWord::m_acht:
-            setFrontMatrixPixel(53);
-            setFrontMatrixPixel(52);
-            setFrontMatrixPixel(51);
-            setFrontMatrixPixel(50); // acht minuten nach
+            setFrontMatrixWord(2, 0, 3);
             break;
 
         case FrontWord::m_neun:
-            setFrontMatrixPixel(42);
-            setFrontMatrixPixel(43);
-            setFrontMatrixPixel(44);
-            setFrontMatrixPixel(45); // neun minuten nach
+            setFrontMatrixWord(2, 8, 11);
             break;
 
         case FrontWord::zehn:
-            setFrontMatrixPixel(54);
-            setFrontMatrixPixel(55);
-            setFrontMatrixPixel(56);
-            setFrontMatrixPixel(57); // zehn minuten nach
+            setFrontMatrixWord(3, 0, 3);
             break;
 
         case FrontWord::m_elf:
-            setFrontMatrixPixel(36);
-            setFrontMatrixPixel(37);
-            setFrontMatrixPixel(37); // elf minuten nach
+            setFrontMatrixWord(2, 15, 17);
             break;
 
         case FrontWord::m_zwoelf:
-            setFrontMatrixPixel(58);
-            setFrontMatrixPixel(59);
-            setFrontMatrixPixel(60);
-            setFrontMatrixPixel(61);
-            setFrontMatrixPixel(62); // zwölf minuten nach
+            setFrontMatrixWord(3, 4, 8);
             break;
 
         case FrontWord::m_dreizehn:
-            setFrontMatrixPixel(35);
-            setFrontMatrixPixel(34);
-            setFrontMatrixPixel(33);
-            setFrontMatrixPixel(32);
-            setFrontMatrixPixel(54);
-            setFrontMatrixPixel(55);
-            setFrontMatrixPixel(56);
-            setFrontMatrixPixel(57); // dreizehn minuten nach
+            setFrontMatrixWord(1, 14, 17);
+            setFrontMatrixWord(3, 0, 3);
             break;
 
         case FrontWord::m_vierzehn:
-            setFrontMatrixPixel(49);
-            setFrontMatrixPixel(48);
-            setFrontMatrixPixel(47);
-            setFrontMatrixPixel(46);
-            setFrontMatrixPixel(54);
-            setFrontMatrixPixel(55);
-            setFrontMatrixPixel(56);
-            setFrontMatrixPixel(57); // vierzehn minuten nach
+            setFrontMatrixWord(2, 4, 7);
+            setFrontMatrixWord(3, 0, 3);
             break;
 
             // viertel nach
-
         case FrontWord::m_sechzehn:
-            setFrontMatrixPixel(24);
-            setFrontMatrixPixel(25);
-            setFrontMatrixPixel(26);
-            setFrontMatrixPixel(54);
-            setFrontMatrixPixel(55);
-            setFrontMatrixPixel(56);
-            setFrontMatrixPixel(57); // sechzehn nach
+            setFrontMatrixWord(1, 7, 10);
+            setFrontMatrixWord(3, 0, 3);
             break;
 
         case FrontWord::m_siebzehn:
-            setFrontMatrixPixel(19);
-            setFrontMatrixPixel(20);
-            setFrontMatrixPixel(21);
-            setFrontMatrixPixel(22);
-            setFrontMatrixPixel(54);
-            setFrontMatrixPixel(55);
-            setFrontMatrixPixel(56);
-            setFrontMatrixPixel(57); // siebzehn nach
+            setFrontMatrixWord(1, 3, 6);
+            setFrontMatrixWord(3, 0, 3);
             break;
 
         case FrontWord::m_achtzehn:
-            setFrontMatrixPixel(53);
-            setFrontMatrixPixel(52);
-            setFrontMatrixPixel(51);
-            setFrontMatrixPixel(50);
-            setFrontMatrixPixel(54);
-            setFrontMatrixPixel(55);
-            setFrontMatrixPixel(56);
-            setFrontMatrixPixel(57); // achtzehn nach
+            setFrontMatrixWord(2, 0, 3);
+            setFrontMatrixWord(3, 0, 3);
             break;
 
         case FrontWord::m_neunzehn:
-            setFrontMatrixPixel(42);
-            setFrontMatrixPixel(43);
-            setFrontMatrixPixel(44);
-            setFrontMatrixPixel(45);
-            setFrontMatrixPixel(53);
-            setFrontMatrixPixel(52);
-            setFrontMatrixPixel(51);
-            setFrontMatrixPixel(50); // neunzehn nach
+            setFrontMatrixWord(2, 8, 11);
+            setFrontMatrixWord(3, 0, 3);
             break;
 
         case FrontWord::zwanzig:
-            setFrontMatrixPixel(76);
-            setFrontMatrixPixel(77);
-            setFrontMatrixPixel(78);
-            setFrontMatrixPixel(79);
-            setFrontMatrixPixel(80);
-            setFrontMatrixPixel(81);
-            setFrontMatrixPixel(82); // zwanzig nach
+            setFrontMatrixWord(4, 7, 13);
             break;
 
         case FrontWord::minute:
-            setFrontMatrixPixel(108);
-            setFrontMatrixPixel(109);
-            setFrontMatrixPixel(110);
-            setFrontMatrixPixel(111);
-            setFrontMatrixPixel(112);
-            setFrontMatrixPixel(113);
+            setFrontMatrixWord(6, 12, 17);
             break;
 
         case FrontWord::minuten:
-            setFrontMatrixPixel(108);
-            setFrontMatrixPixel(109);
-            setFrontMatrixPixel(110);
-            setFrontMatrixPixel(111);
-            setFrontMatrixPixel(112);
-            setFrontMatrixPixel(113);
-            setFrontMatrixPixel(114);
-            break;
+            setFrontMatrixWord(6, 11, 17);
 
         default:
             break;
         }
 
         switch (word) {
-
         case FrontWord::es_ist:
-            setFrontMatrixPixel(0);
-            setFrontMatrixPixel(1);
-
-            setFrontMatrixPixel(3);
-            setFrontMatrixPixel(4);
-            setFrontMatrixPixel(5);
+            setFrontMatrixWord(0, 16, 17);
+            setFrontMatrixWord(0, 12, 14);
             break;
 
         case FrontWord::nach:
+            break;
+
         case FrontWord::v_nach:
-            setFrontMatrixPixel(122);
-            setFrontMatrixPixel(123);
-            setFrontMatrixPixel(124);
-            setFrontMatrixPixel(125);
+            setFrontMatrixWord(6, 0, 3);
             break;
 
         case FrontWord::vor:
+            break;
+
         case FrontWord::v_vor:
-            setFrontMatrixPixel(116);
-            setFrontMatrixPixel(117);
-            setFrontMatrixPixel(118);
+            setFrontMatrixWord(6, 7, 9);
             break;
 
         case FrontWord::viertel:
-            setFrontMatrixPixel(7);
-            setFrontMatrixPixel(8);
-            setFrontMatrixPixel(9);
-            setFrontMatrixPixel(10);
-            setFrontMatrixPixel(11);
-            setFrontMatrixPixel(12);
-            setFrontMatrixPixel(13);
+            setFrontMatrixWord(0, 4, 10);
             break;
 
         case FrontWord::dreiviertel:
-            setFrontMatrixPixel(140);
-            setFrontMatrixPixel(139);
-            setFrontMatrixPixel(138);
-            setFrontMatrixPixel(137);
-            setFrontMatrixPixel(136);
-            setFrontMatrixPixel(135);
-            setFrontMatrixPixel(134);
-            setFrontMatrixPixel(133);
-            setFrontMatrixPixel(132);
-            setFrontMatrixPixel(131);
-            setFrontMatrixPixel(130);
+            setFrontMatrixWord(7, 4, 14);
             break;
 
         case FrontWord::halb:
-            setFrontMatrixPixel(126);
-            setFrontMatrixPixel(127);
-            setFrontMatrixPixel(128);
-            setFrontMatrixPixel(129);
+            setFrontMatrixWord(7, 0, 3);
             break;
 
         case FrontWord::frueh:
-            setFrontMatrixPixel(227);
-            setFrontMatrixPixel(228);
-            setFrontMatrixPixel(229);
-            setFrontMatrixPixel(230);
+            setFrontMatrixWord(13, 3, 6);
             break;
 
         case FrontWord::minuten_uhr:
-            setFrontMatrixPixel(232);
-            setFrontMatrixPixel(233);
-            setFrontMatrixPixel(234);
+            setFrontMatrixWord(13, 8, 11);
             break;
 
         case FrontWord::minuten_extra:
-            setFrontMatrixPixel(235);
-            setFrontMatrixPixel(236);
-            setFrontMatrixPixel(237);
-            setFrontMatrixPixel(238);
-            setFrontMatrixPixel(239);
-            setFrontMatrixPixel(240);
-            setFrontMatrixPixel(241);
+            setFrontMatrixWord(13, 11, 17);
             break;
 
         case FrontWord::abends:
-            setFrontMatrixPixel(242);
-            setFrontMatrixPixel(243);
-            setFrontMatrixPixel(244);
-            setFrontMatrixPixel(245);
-            setFrontMatrixPixel(246);
-            setFrontMatrixPixel(247);
+            setFrontMatrixWord(14, 12, 17);
             break;
 
         case FrontWord::mitternacht:
-            setFrontMatrixPixel(248);
-            setFrontMatrixPixel(249);
-            setFrontMatrixPixel(250);
-            setFrontMatrixPixel(251);
-            setFrontMatrixPixel(252);
-            setFrontMatrixPixel(253);
-            setFrontMatrixPixel(254);
-            setFrontMatrixPixel(255);
-            setFrontMatrixPixel(256);
-            setFrontMatrixPixel(257);
-            setFrontMatrixPixel(258);
+            setFrontMatrixWord(14, 1, 11);
             break;
 
         case FrontWord::mittags:
-            setFrontMatrixPixel(260);
-            setFrontMatrixPixel(261);
-            setFrontMatrixPixel(262);
-            setFrontMatrixPixel(263);
-            setFrontMatrixPixel(264);
-            setFrontMatrixPixel(265);
-            setFrontMatrixPixel(266);
+            setFrontMatrixWord(15, 0, 6);
             break;
 
         case FrontWord::warm:
-            setFrontMatrixPixel(267);
-            setFrontMatrixPixel(268);
-            setFrontMatrixPixel(269);
-            setFrontMatrixPixel(270);
+            setFrontMatrixWord(14, 7, 10);
             break;
 
         case FrontWord::morgens:
-            setFrontMatrixPixel(271);
-            setFrontMatrixPixel(272);
-            setFrontMatrixPixel(273);
-            setFrontMatrixPixel(274);
-            setFrontMatrixPixel(275);
-            setFrontMatrixPixel(276);
-            setFrontMatrixPixel(277);
+            setFrontMatrixWord(15, 11, 17);
             break;
 
         case FrontWord::uhr:
-            setFrontMatrixPixel(87);
-            setFrontMatrixPixel(88);
-            setFrontMatrixPixel(89);
+            setFrontMatrixWord(5, 0, 2);
             break;
 
         case FrontWord::und:
-            setFrontMatrixPixel(101);
-            setFrontMatrixPixel(102);
-            setFrontMatrixPixel(103);
-            break;
+            setFrontMatrixWord(6, 4, 6);
 
             // Stunden
+            break;
 
         case FrontWord::h_ein:
-            setFrontMatrixPixel(14);
-            setFrontMatrixPixel(15);
-            setFrontMatrixPixel(16);
-            setFrontMatrixPixel(17);
+            setFrontMatrixWord(0, 0, 3);
             break;
 
         case FrontWord::h_zwei:
-            setFrontMatrixPixel(64);
-            setFrontMatrixPixel(65);
-            setFrontMatrixPixel(66);
-            setFrontMatrixPixel(67);
+            setFrontMatrixWord(3, 10, 13);
             break;
 
         case FrontWord::h_drei:
-            setFrontMatrixPixel(32);
-            setFrontMatrixPixel(33);
-            setFrontMatrixPixel(34);
-            setFrontMatrixPixel(35);
+            setFrontMatrixWord(1, 14, 17);
             break;
 
         case FrontWord::h_vier:
-            setFrontMatrixPixel(46);
-            setFrontMatrixPixel(47);
-            setFrontMatrixPixel(48);
-            setFrontMatrixPixel(49);
+            setFrontMatrixWord(2, 4, 7);
             break;
 
         case FrontWord::h_fuenf:
-            setFrontMatrixPixel(38);
-            setFrontMatrixPixel(39);
-            setFrontMatrixPixel(40);
-            setFrontMatrixPixel(41);
+            setFrontMatrixWord(2, 12, 15);
             break;
 
         case FrontWord::h_sechs:
-            setFrontMatrixPixel(24);
-            setFrontMatrixPixel(25);
-            setFrontMatrixPixel(26);
-            setFrontMatrixPixel(27);
-            setFrontMatrixPixel(28);
+            setFrontMatrixWord(1, 6, 10);
             break;
 
         case FrontWord::h_sieben:
-            setFrontMatrixPixel(19);
-            setFrontMatrixPixel(20);
-            setFrontMatrixPixel(21);
-            setFrontMatrixPixel(22);
-            setFrontMatrixPixel(23);
-            setFrontMatrixPixel(24);
+            setFrontMatrixWord(1, 1, 6);
             break;
 
         case FrontWord::h_acht:
-            setFrontMatrixPixel(50);
-            setFrontMatrixPixel(51);
-            setFrontMatrixPixel(52);
-            setFrontMatrixPixel(53);
+            setFrontMatrixWord(2, 0, 3);
             break;
 
         case FrontWord::h_neun:
-            setFrontMatrixPixel(42);
-            setFrontMatrixPixel(43);
-            setFrontMatrixPixel(44);
-            setFrontMatrixPixel(45);
+            setFrontMatrixWord(2, 8, 11);
             break;
 
         case FrontWord::h_zehn:
-            setFrontMatrixPixel(54);
-            setFrontMatrixPixel(55);
-            setFrontMatrixPixel(56);
-            setFrontMatrixPixel(57);
+            setFrontMatrixWord(3, 0, 3);
             break;
 
         case FrontWord::h_elf:
-            setFrontMatrixPixel(36);
-            setFrontMatrixPixel(37);
-            setFrontMatrixPixel(38);
+            setFrontMatrixWord(2, 15, 17);
             break;
 
         case FrontWord::h_zwoelf:
-            setFrontMatrixPixel(58);
-            setFrontMatrixPixel(59);
-            setFrontMatrixPixel(60);
-            setFrontMatrixPixel(61);
-            setFrontMatrixPixel(62);
-            break;
-
-        case FrontWord::h_dreizehn:
-            setFrontMatrixPixel(14);
-            setFrontMatrixPixel(15);
-            setFrontMatrixPixel(16);
-            setFrontMatrixPixel(17);
+            setFrontMatrixWord(3, 4, 8);
             break;
 
         default:

--- a/include/Uhrtypes/DE22x11.weather.hpp
+++ b/include/Uhrtypes/DE22x11.weather.hpp
@@ -3,31 +3,33 @@
 #include "Uhrtype.hpp"
 
 /*
- * Layout Front
+ *           Layout Front
+ *                COL
+ *       X 9 8 7 6 5 4 3 2 1 0
+ * ROW + - - - - - - - - - - -
+ *  0  | E S K I S T L F Ü N F
+ *  1  | Z E H N Z W A N Z I G
+ *  2  | D R E I V I E R T E L
+ *  3  | T G N A C H V O R J M
+ *  4  | H A L B Q Z W Ö L F P
+ *  5  | Z W E I N S I E B E N
+ *  6  | K D R E I R H F Ü N F
+ *  7  | E L F N E U N V I E R
+ *  8  | W A C H T Z E H N B X
+ *  9  | B S E C H S F U H R M
  *
- * E S K I S T L F Ü N F
- * Z E H N Z W A N Z I G
- * D R E I V I E R T E L
- * T G N A C H V O R J M
- * H A L B Q Z W Ö L F P
- * Z W E I N S I E B E N
- * K D R E I R H F Ü N F
- * E L F N E U N V I E R
- * W A C H T Z E H N B X
- * B S E C H S F U H R M
+ *  X  |        X X X X
  *
- *
- *
- * M O R G E N X F R Ü H
- * A B E N D M I T T A G
- * N A C H T S C H N E E
- * K L A R W A R N U N G
- * R E G E N W O L K E N
- * O G E W I T T E R B N
- * U N T E R Z Ü B E R K
- * Y M I N U S A N U L L
- * H N Z W A N Z I G J T
- * D R E I ẞ I G O ° C X
+ *  1  | M O R G E N X F R Ü H
+ *  2  | A B E N D M I T T A G
+ *  3  | N A C H T S C H N E E
+ *  4  | K L A R W A R N U N G
+ *  5  | R E G E N W O L K E N
+ *  6  | O G E W I T T E R B N
+ *  7  | U N T E R Z Ü B E R K
+ *  8  | Y M I N U S A N U L L
+ *  9  | H N Z W A N Z I G J T
+ *  X  | D R E I ẞ I G O ° C X
  */
 
 class De22x11Weather_t : public iUhrType {
@@ -46,6 +48,7 @@ public:
                 // {113, 114, 115, 116}
                 returnArr[i] = 113 + i;
                 break;
+
             case 1:
                 // LEDs for "LED7x" minute display
                 // {112, 114, 116, 118}
@@ -73,14 +76,9 @@ public:
 
         case FrontWord::es_ist:
             // Es
-            setFrontMatrixPixel(0);
-            setFrontMatrixPixel(1);
-
+            setFrontMatrixWord(0, 9, 10);
             // Ist
-            setFrontMatrixPixel(3);
-            setFrontMatrixPixel(4);
-            setFrontMatrixPixel(5);
-
+            setFrontMatrixWord(0, 5, 7);
 #if WEATHER_VERBOSE
             Serial.println("");
             Serial.print("Es ist ");
@@ -88,72 +86,42 @@ public:
             break;
 
         case FrontWord::viertel:
-            setFrontMatrixPixel(26);
-            setFrontMatrixPixel(27);
-            setFrontMatrixPixel(28);
-            setFrontMatrixPixel(29);
-            setFrontMatrixPixel(30);
-            setFrontMatrixPixel(31);
-            setFrontMatrixPixel(32);
-
+            setFrontMatrixWord(2, 0, 6);
 #if WEATHER_VERBOSE
             Serial.print("viertel ");
 #endif
             break;
 
         case FrontWord::fuenf:
-            setFrontMatrixPixel(7);
-            setFrontMatrixPixel(8);
-            setFrontMatrixPixel(9);
-            setFrontMatrixPixel(10);
-
+            setFrontMatrixWord(0, 0, 3);
 #if WEATHER_VERBOSE
             Serial.print("Fünf ");
 #endif
             break;
 
         case FrontWord::zehn:
-            setFrontMatrixPixel(18);
-            setFrontMatrixPixel(19);
-            setFrontMatrixPixel(20);
-            setFrontMatrixPixel(21);
-
+            setFrontMatrixWord(1, 7, 10);
 #if WEATHER_VERBOSE
             Serial.print("zehn ");
 #endif
             break;
 
         case FrontWord::zwanzig:
-            setFrontMatrixPixel(11);
-            setFrontMatrixPixel(12);
-            setFrontMatrixPixel(13);
-            setFrontMatrixPixel(14);
-            setFrontMatrixPixel(15);
-            setFrontMatrixPixel(16);
-            setFrontMatrixPixel(17);
-
+            setFrontMatrixWord(1, 0, 6);
 #if WEATHER_VERBOSE
             Serial.print("zwanzig ");
 #endif
             break;
 
         case FrontWord::halb:
-            setFrontMatrixPixel(44);
-            setFrontMatrixPixel(45);
-            setFrontMatrixPixel(46);
-            setFrontMatrixPixel(47);
-
+            setFrontMatrixWord(4, 7, 10);
 #if WEATHER_VERBOSE
             Serial.print("halb ");
 #endif
             break;
 
         case FrontWord::eins:
-            setFrontMatrixPixel(60);
-            setFrontMatrixPixel(61);
-            setFrontMatrixPixel(62);
-            setFrontMatrixPixel(63);
-
+            setFrontMatrixWord(5, 5, 8);
 #if WEATHER_VERBOSE
             Serial.print("Eins ");
 #endif
@@ -161,11 +129,7 @@ public:
 
         case FrontWord::nach:
         case FrontWord::v_nach:
-            setFrontMatrixPixel(38);
-            setFrontMatrixPixel(39);
-            setFrontMatrixPixel(40);
-            setFrontMatrixPixel(41);
-
+            setFrontMatrixWord(3, 5, 8);
 #if WEATHER_VERBOSE
             Serial.print("nach ");
 #endif
@@ -173,153 +137,97 @@ public:
 
         case FrontWord::vor:
         case FrontWord::v_vor:
-            setFrontMatrixPixel(35);
-            setFrontMatrixPixel(36);
-            setFrontMatrixPixel(37);
-
+            setFrontMatrixWord(3, 2, 4);
 #if WEATHER_VERBOSE
             Serial.print("vor ");
 #endif
 
         case FrontWord::uhr:
-            setFrontMatrixPixel(100);
-            setFrontMatrixPixel(101);
-            setFrontMatrixPixel(102);
-
+            setFrontMatrixWord(9, 1, 3);
 #if WEATHER_VERBOSE
             Serial.println("Uhr ");
 #endif
             break;
 
         case FrontWord::h_ein:
-            setFrontMatrixPixel(61);
-            setFrontMatrixPixel(62);
-            setFrontMatrixPixel(63);
-
+            setFrontMatrixWord(5, 6, 8);
 #if WEATHER_VERBOSE
             Serial.println("Eins ");
 #endif
             break;
 
         case FrontWord::h_zwei:
-            setFrontMatrixPixel(62);
-            setFrontMatrixPixel(63);
-            setFrontMatrixPixel(64);
-            setFrontMatrixPixel(65);
-
+            setFrontMatrixWord(5, 7, 10);
 #if WEATHER_VERBOSE
             Serial.println("Zwei ");
 #endif
             break;
 
         case FrontWord::h_drei:
-            setFrontMatrixPixel(67);
-            setFrontMatrixPixel(68);
-            setFrontMatrixPixel(69);
-            setFrontMatrixPixel(70);
-
+            setFrontMatrixWord(6, 6, 9);
 #if WEATHER_VERBOSE
             Serial.println("Drei ");
 #endif
             break;
 
         case FrontWord::h_vier:
-            setFrontMatrixPixel(77);
-            setFrontMatrixPixel(78);
-            setFrontMatrixPixel(79);
-            setFrontMatrixPixel(80);
-
+            setFrontMatrixWord(7, 0, 3);
 #if WEATHER_VERBOSE
             Serial.println("Vier ");
 #endif
             break;
 
         case FrontWord::h_fuenf:
-            setFrontMatrixPixel(73);
-            setFrontMatrixPixel(74);
-            setFrontMatrixPixel(75);
-            setFrontMatrixPixel(76);
-
+            setFrontMatrixWord(6, 0, 3);
 #if WEATHER_VERBOSE
             Serial.println("Fünf ");
 #endif
             break;
 
         case FrontWord::h_sechs:
-            setFrontMatrixPixel(104);
-            setFrontMatrixPixel(105);
-            setFrontMatrixPixel(106);
-            setFrontMatrixPixel(107);
-            setFrontMatrixPixel(108);
-
+            setFrontMatrixWord(9, 5, 9);
 #if WEATHER_VERBOSE
             Serial.println("Sechs ");
 #endif
             break;
 
         case FrontWord::h_sieben:
-            setFrontMatrixPixel(55);
-            setFrontMatrixPixel(56);
-            setFrontMatrixPixel(57);
-            setFrontMatrixPixel(58);
-            setFrontMatrixPixel(59);
-            setFrontMatrixPixel(60);
-
+            setFrontMatrixWord(5, 0, 5);
 #if WEATHER_VERBOSE
             Serial.println("Sieben ");
 #endif
             break;
 
         case FrontWord::h_acht:
-            setFrontMatrixPixel(89);
-            setFrontMatrixPixel(90);
-            setFrontMatrixPixel(91);
-            setFrontMatrixPixel(92);
-
+            setFrontMatrixWord(8, 6, 9);
 #if WEATHER_VERBOSE
             Serial.println("Acht ");
 #endif
             break;
 
         case FrontWord::h_neun:
-            setFrontMatrixPixel(81);
-            setFrontMatrixPixel(82);
-            setFrontMatrixPixel(83);
-            setFrontMatrixPixel(84);
-
+            setFrontMatrixWord(7, 4, 7);
 #if WEATHER_VERBOSE
             Serial.println("Neun ");
 #endif
             break;
 
         case FrontWord::h_zehn:
-            setFrontMatrixPixel(93);
-            setFrontMatrixPixel(94);
-            setFrontMatrixPixel(95);
-            setFrontMatrixPixel(96);
-
+            setFrontMatrixWord(8, 2, 5);
 #if WEATHER_VERBOSE
             Serial.println("Zehn ");
 #endif
             break;
 
         case FrontWord::h_elf:
-            setFrontMatrixPixel(85);
-            setFrontMatrixPixel(86);
-            setFrontMatrixPixel(87);
-
+            setFrontMatrixWord(7, 8, 10);
 #if WEATHER_VERBOSE
             Serial.println("Elf ");
 #endif
             break;
 
         case FrontWord::h_zwoelf:
-            setFrontMatrixPixel(49);
-            setFrontMatrixPixel(50);
-            setFrontMatrixPixel(51);
-            setFrontMatrixPixel(52);
-            setFrontMatrixPixel(53);
-
+            setFrontMatrixWord(4, 1, 5);
 #if WEATHER_VERBOSE
             Serial.println("Zwölf ");
 #endif
@@ -330,254 +238,147 @@ public:
             //------------------------------------------------------------------------------
 
         case FrontWord::w_morgen:
-            setFrontMatrixPixel(131);
-            setFrontMatrixPixel(130);
-            setFrontMatrixPixel(129);
-            setFrontMatrixPixel(128);
-            setFrontMatrixPixel(127);
-            setFrontMatrixPixel(126);
-
+            setFrontMatrixWord(11, 5, 10);
 #if WEATHER_VERBOSE
             Serial.print("Morgen ");
 #endif
             break;
 
         case FrontWord::w_frueh:
-            setFrontMatrixPixel(124);
-            setFrontMatrixPixel(123);
-            setFrontMatrixPixel(122);
-            setFrontMatrixPixel(121);
-
+            setFrontMatrixWord(11, 0, 3);
 #if WEATHER_VERBOSE
             Serial.print("Früh ");
 #endif
             break;
 
         case FrontWord::w_abend:
-            setFrontMatrixPixel(132);
-            setFrontMatrixPixel(133);
-            setFrontMatrixPixel(134);
-            setFrontMatrixPixel(135);
-            setFrontMatrixPixel(136);
-
+            setFrontMatrixWord(12, 6, 10);
 #if WEATHER_VERBOSE
             Serial.print("Abend ");
 #endif
             break;
 
         case FrontWord::w_mittag:
-            setFrontMatrixPixel(137);
-            setFrontMatrixPixel(138);
-            setFrontMatrixPixel(139);
-            setFrontMatrixPixel(140);
-            setFrontMatrixPixel(141);
-            setFrontMatrixPixel(142);
-
+            setFrontMatrixWord(12, 0, 5);
 #if WEATHER_VERBOSE
             Serial.print("Mittag ");
 #endif
             break;
 
         case FrontWord::w_nacht:
-            setFrontMatrixPixel(153);
-            setFrontMatrixPixel(152);
-            setFrontMatrixPixel(151);
-            setFrontMatrixPixel(150);
-            setFrontMatrixPixel(149);
-
+            setFrontMatrixWord(13, 6, 10);
 #if WEATHER_VERBOSE
             Serial.print("Nacht ");
 #endif
             break;
 
         case FrontWord::w_schnee:
-            setFrontMatrixPixel(148);
-            setFrontMatrixPixel(147);
-            setFrontMatrixPixel(146);
-            setFrontMatrixPixel(145);
-            setFrontMatrixPixel(144);
-            setFrontMatrixPixel(143);
-
+            setFrontMatrixWord(13, 0, 5);
 #if WEATHER_VERBOSE
             Serial.print("Schnee ");
 #endif
             break;
 
         case FrontWord::w_klar:
-            setFrontMatrixPixel(154);
-            setFrontMatrixPixel(155);
-            setFrontMatrixPixel(156);
-            setFrontMatrixPixel(157);
-
+            setFrontMatrixWord(14, 7, 10);
 #if WEATHER_VERBOSE
             Serial.print("klar ");
 #endif
             break;
 
         case FrontWord::w_warnung:
-            setFrontMatrixPixel(158);
-            setFrontMatrixPixel(159);
-            setFrontMatrixPixel(160);
-            setFrontMatrixPixel(161);
-            setFrontMatrixPixel(162);
-            setFrontMatrixPixel(163);
-            setFrontMatrixPixel(164);
-
+            setFrontMatrixWord(14, 0, 6);
 #if WEATHER_VERBOSE
             Serial.print("Warnung ");
 #endif
             break;
 
         case FrontWord::w_regen:
-            setFrontMatrixPixel(175);
-            setFrontMatrixPixel(174);
-            setFrontMatrixPixel(173);
-            setFrontMatrixPixel(172);
-            setFrontMatrixPixel(171);
-
+            setFrontMatrixWord(15, 6, 10);
 #if WEATHER_VERBOSE
             Serial.print("Regen ");
 #endif
             break;
 
         case FrontWord::w_wolken:
-            setFrontMatrixPixel(170);
-            setFrontMatrixPixel(169);
-            setFrontMatrixPixel(168);
-            setFrontMatrixPixel(167);
-            setFrontMatrixPixel(166);
-            setFrontMatrixPixel(165);
-
+            setFrontMatrixWord(15, 0, 5);
 #if WEATHER_VERBOSE
             Serial.print("Wolken ");
 #endif
             break;
 
         case FrontWord::w_gewitter:
-            setFrontMatrixPixel(177);
-            setFrontMatrixPixel(178);
-            setFrontMatrixPixel(179);
-            setFrontMatrixPixel(180);
-            setFrontMatrixPixel(181);
-            setFrontMatrixPixel(182);
-            setFrontMatrixPixel(183);
-            setFrontMatrixPixel(184);
-
+            setFrontMatrixWord(16, 2, 9);
 #if WEATHER_VERBOSE
             Serial.print("Gewitter ");
 #endif
             break;
 
         case FrontWord::w_unter:
-            setFrontMatrixPixel(197);
-            setFrontMatrixPixel(196);
-            setFrontMatrixPixel(195);
-            setFrontMatrixPixel(194);
-            setFrontMatrixPixel(193);
-
+            setFrontMatrixWord(17, 6, 10);
 #if WEATHER_VERBOSE
             Serial.print("unter ");
 #endif
             break;
 
         case FrontWord::w_ueber:
-            setFrontMatrixPixel(191);
-            setFrontMatrixPixel(190);
-            setFrontMatrixPixel(189);
-            setFrontMatrixPixel(188);
-
+            setFrontMatrixWord(17, 1, 4);
 #if WEATHER_VERBOSE
             Serial.print("über ");
 #endif
             break;
 
         case FrontWord::w_minus:
-            setFrontMatrixPixel(199);
-            setFrontMatrixPixel(200);
-            setFrontMatrixPixel(201);
-            setFrontMatrixPixel(202);
-            setFrontMatrixPixel(203);
-
+            setFrontMatrixWord(18, 5, 9);
 #if WEATHER_VERBOSE
             Serial.print("minus ");
 #endif
             break;
 
         case FrontWord::w_null:
-            setFrontMatrixPixel(205);
-            setFrontMatrixPixel(206);
-            setFrontMatrixPixel(207);
-            setFrontMatrixPixel(208);
-
+            setFrontMatrixWord(18, 0, 3);
 #if WEATHER_VERBOSE
             Serial.print("Null ");
 #endif
             break;
 
         case FrontWord::w_fuenf:
-            setFrontMatrixPixel(219);
-            setFrontMatrixPixel(218);
-            setFrontMatrixPixel(217);
-            setFrontMatrixPixel(216);
-
+            setFrontMatrixWord(19, 7, 10);
 #if WEATHER_VERBOSE
             Serial.print("Fünf ");
 #endif
             break;
 
         case FrontWord::w_zehn:
-            setFrontMatrixPixel(215);
-            setFrontMatrixPixel(214);
-            setFrontMatrixPixel(213);
-            setFrontMatrixPixel(212);
-
+            setFrontMatrixWord(19, 3, 6);
 #if WEATHER_VERBOSE
             Serial.print("Zehn ");
 #endif
             break;
 
         case FrontWord::w_und:
-            setFrontMatrixPixel(211);
-            setFrontMatrixPixel(210);
-            setFrontMatrixPixel(209);
-
+            setFrontMatrixWord(19, 0, 2);
 #if WEATHER_VERBOSE
             Serial.print("und ");
 #endif
             break;
 
         case FrontWord::w_zwanzig:
-            setFrontMatrixPixel(222);
-            setFrontMatrixPixel(223);
-            setFrontMatrixPixel(224);
-            setFrontMatrixPixel(225);
-            setFrontMatrixPixel(226);
-            setFrontMatrixPixel(227);
-            setFrontMatrixPixel(228);
-
+            setFrontMatrixWord(20, 2, 8);
 #if WEATHER_VERBOSE
             Serial.print("Zwanzig ");
 #endif
             break;
 
         case FrontWord::w_dreissig:
-            setFrontMatrixPixel(241);
-            setFrontMatrixPixel(240);
-            setFrontMatrixPixel(239);
-            setFrontMatrixPixel(238);
-            setFrontMatrixPixel(237);
-            setFrontMatrixPixel(236);
-            setFrontMatrixPixel(235);
-
+            setFrontMatrixWord(21, 4, 10);
 #if WEATHER_VERBOSE
             Serial.print("Dreißig ");
 #endif
             break;
 
         case FrontWord::w_grad:
-            setFrontMatrixPixel(233);
-            setFrontMatrixPixel(232);
-
+            setFrontMatrixWord(21, 1, 2);
 #if WEATHER_VERBOSE
             Serial.println("°C ");
 #endif

--- a/include/Uhrtypes/EN10x11.hpp
+++ b/include/Uhrtypes/EN10x11.hpp
@@ -3,19 +3,20 @@
 #include "Uhrtype.hpp"
 
 /*
- * Layout Front
- *
- * I T L I S A S A M P M
- * A C Q U A R T E R D C
- * T W E N T Y F I V E X
- * H A L F S T E N F T O
- * P A S T E R U N I N E
- * O N E S I X T H R E E
- * F O U R F I V E T W O
- * E I G H T E L E V E N
- * S E V E N T W E L V E
- * T E N S E O'C L O C K
- *
+ *           Layout Front
+ *                COL
+ *       X 9 8 7 6 5 4 3 2 1 0
+ * ROW + - - - - - - - - - - -
+ *  0  | I T L I S A S A M P M
+ *  1  | A C Q U A R T E R D C
+ *  2  | T W E N T Y F I V E X
+ *  3  | H A L F S T E N F T O
+ *  4  | P A S T E R U N I N E
+ *  5  | O N E S I X T H R E E
+ *  6  | F O U R F I V E T W O
+ *  7  | E I G H T E L E V E N
+ *  8  | S E V E N T W E L V E
+ *  9  | T E N S E O'C L O C K
  */
 
 class En10x11_t : public iUhrType {
@@ -39,206 +40,120 @@ public:
 
         case FrontWord::es_ist:
             // It
-            setFrontMatrixPixel(0);
-            setFrontMatrixPixel(1);
-            // is
-            setFrontMatrixPixel(3);
-            setFrontMatrixPixel(4);
+            setFrontMatrixWord(0, 9, 10);
+            setFrontMatrixWord(0, 6, 7);
             break;
 
         case FrontWord::h_ein:
             // One
-            setFrontMatrixPixel(65);
-            setFrontMatrixPixel(64);
-            setFrontMatrixPixel(63);
+            setFrontMatrixWord(5, 8, 10);
             break;
 
         case FrontWord::h_zwei:
             // Two
-            setFrontMatrixPixel(74);
-            setFrontMatrixPixel(75);
-            setFrontMatrixPixel(76);
+            setFrontMatrixWord(6, 0, 2);
             break;
 
         case FrontWord::h_drei:
             // Three
-            setFrontMatrixPixel(59);
-            setFrontMatrixPixel(58);
-            setFrontMatrixPixel(57);
-            setFrontMatrixPixel(56);
-            setFrontMatrixPixel(55);
+            setFrontMatrixWord(5, 0, 4);
             break;
 
         case FrontWord::h_vier:
             // Four
-            setFrontMatrixPixel(66);
-            setFrontMatrixPixel(67);
-            setFrontMatrixPixel(68);
-            setFrontMatrixPixel(69);
+            setFrontMatrixWord(6, 7, 10);
             break;
 
         case FrontWord::h_fuenf:
             // Five
-            setFrontMatrixPixel(70);
-            setFrontMatrixPixel(71);
-            setFrontMatrixPixel(72);
-            setFrontMatrixPixel(73);
+            setFrontMatrixWord(6, 3, 6);
             break;
 
         case FrontWord::h_sechs:
             // Six
-            setFrontMatrixPixel(62);
-            setFrontMatrixPixel(61);
-            setFrontMatrixPixel(60);
+            setFrontMatrixWord(5, 5, 7);
             break;
 
         case FrontWord::h_sieben:
             // Seven
-            setFrontMatrixPixel(88);
-            setFrontMatrixPixel(89);
-            setFrontMatrixPixel(90);
-            setFrontMatrixPixel(91);
-            setFrontMatrixPixel(92);
+            setFrontMatrixWord(8, 6, 10);
             break;
 
         case FrontWord::h_acht:
             // Eight
-            setFrontMatrixPixel(87);
-            setFrontMatrixPixel(86);
-            setFrontMatrixPixel(85);
-            setFrontMatrixPixel(84);
-            setFrontMatrixPixel(83);
+            setFrontMatrixWord(7, 6, 10);
             break;
 
         case FrontWord::h_neun:
             // Nine
-            setFrontMatrixPixel(51);
-            setFrontMatrixPixel(52);
-            setFrontMatrixPixel(53);
-            setFrontMatrixPixel(54);
+            setFrontMatrixWord(4, 0, 3);
             break;
 
         case FrontWord::h_zehn:
             // Ten
-            setFrontMatrixPixel(109);
-            setFrontMatrixPixel(108);
-            setFrontMatrixPixel(107);
+            setFrontMatrixWord(9, 8, 10);
             break;
 
         case FrontWord::h_elf:
             // Eleven
-            setFrontMatrixPixel(82);
-            setFrontMatrixPixel(81);
-            setFrontMatrixPixel(80);
-            setFrontMatrixPixel(79);
-            setFrontMatrixPixel(78);
-            setFrontMatrixPixel(77);
+            setFrontMatrixWord(7, 0, 5);
             break;
 
         case FrontWord::h_zwoelf:
             // Twelve
-            setFrontMatrixPixel(93);
-            setFrontMatrixPixel(94);
-            setFrontMatrixPixel(95);
-            setFrontMatrixPixel(96);
-            setFrontMatrixPixel(97);
-            setFrontMatrixPixel(98);
+            setFrontMatrixWord(8, 0, 5);
             break;
 
         case FrontWord::fuenf:
             // Five
-            setFrontMatrixPixel(28);
-            setFrontMatrixPixel(29);
-            setFrontMatrixPixel(30);
-            setFrontMatrixPixel(31);
+            setFrontMatrixWord(2, 1, 4);
             break;
 
         case FrontWord::zehn:
             // Ten
-            setFrontMatrixPixel(38);
-            setFrontMatrixPixel(37);
-            setFrontMatrixPixel(36);
+            setFrontMatrixWord(3, 3, 5);
             break;
 
         case FrontWord::a_quarter:
             // A Quater
-            setFrontMatrixPixel(21);
-            setFrontMatrixPixel(13);
-            setFrontMatrixPixel(14);
-            setFrontMatrixPixel(15);
-            setFrontMatrixPixel(16);
-            setFrontMatrixPixel(17);
-            setFrontMatrixPixel(18);
-            setFrontMatrixPixel(19);
+            setFrontMatrixWord(1, 2, 9);
             break;
 
         case FrontWord::viertel:
             // Quater
-            setFrontMatrixPixel(13);
-            setFrontMatrixPixel(14);
-            setFrontMatrixPixel(15);
-            setFrontMatrixPixel(16);
-            setFrontMatrixPixel(17);
-            setFrontMatrixPixel(18);
-            setFrontMatrixPixel(19);
+            setFrontMatrixWord(1, 2, 8);
             break;
 
         case FrontWord::zwanzig:
             // Twenty
-            setFrontMatrixPixel(22);
-            setFrontMatrixPixel(23);
-            setFrontMatrixPixel(24);
-            setFrontMatrixPixel(25);
-            setFrontMatrixPixel(26);
-            setFrontMatrixPixel(27);
+            setFrontMatrixWord(2, 5, 10);
             break;
 
         case FrontWord::twentyfive:
             // Twentyfive
-            setFrontMatrixPixel(22);
-            setFrontMatrixPixel(23);
-            setFrontMatrixPixel(24);
-            setFrontMatrixPixel(25);
-            setFrontMatrixPixel(26);
-            setFrontMatrixPixel(27);
-            setFrontMatrixPixel(28);
-            setFrontMatrixPixel(29);
-            setFrontMatrixPixel(30);
-            setFrontMatrixPixel(31);
+            setFrontMatrixWord(2, 1, 10);
             break;
 
         case FrontWord::halb:
             // Half
-            setFrontMatrixPixel(43);
-            setFrontMatrixPixel(42);
-            setFrontMatrixPixel(41);
-            setFrontMatrixPixel(40);
+            setFrontMatrixWord(3, 7, 10);
             break;
 
         case FrontWord::nach:
         case FrontWord::v_nach:
             // Past
-            setFrontMatrixPixel(44);
-            setFrontMatrixPixel(45);
-            setFrontMatrixPixel(46);
-            setFrontMatrixPixel(47);
+            setFrontMatrixWord(4, 7, 10);
             break;
 
         case FrontWord::vor:
         case FrontWord::v_vor:
             // To
-            setFrontMatrixPixel(34);
-            setFrontMatrixPixel(33);
+            setFrontMatrixWord(3, 0, 1);
             break;
 
         case FrontWord::uhr:
             // O'Clock
-            setFrontMatrixPixel(104);
-            setFrontMatrixPixel(103);
-            setFrontMatrixPixel(102);
-            setFrontMatrixPixel(101);
-            setFrontMatrixPixel(100);
-            setFrontMatrixPixel(99);
+            setFrontMatrixWord(9, 0, 5);
             break;
 
         default:

--- a/include/Uhrtypes/NL10x11.hpp
+++ b/include/Uhrtypes/NL10x11.hpp
@@ -3,19 +3,20 @@
 #include "Uhrtype.hpp"
 
 /*
- * Layout Front
- *
- * H E T L I S H N U W S
- * T W I N T I G T I E N
- * V I J F B Y K W A R T
- * V O O R P M O V E R U
- * H A L F I T W E E N N
- * A C H T D R I E Z E S
- * Z E V E N E G E N T O
- * T W A A L F A T I E N
- * V I E R V I J F E L F
- * U U R A G E W E E S T
- *
+ *           Layout Front
+ *                COL
+ *       X 9 8 7 6 5 4 3 2 1 0
+ * ROW + - - - - - - - - - - -
+ *  0  | H E T L I S H N U W S
+ *  1  | T W I N T I G T I E N
+ *  2  | V I J F B Y K W A R T
+ *  3  | V O O R P M O V E R U
+ *  4  | H A L F I T W E E N N
+ *  5  | A C H T D R I E Z E S
+ *  6  | Z E V E N E G E N T O
+ *  7  | T W A A L F A T I E N
+ *  8  | V I E R V I J F E L F
+ *  9  | U U R A G E W E E S T
  */
 
 class NL10x11_t : public iUhrType {
@@ -30,177 +31,100 @@ public:
         switch (word) {
 
         case FrontWord::es_ist:
-            // Es
-            setFrontMatrixPixel(0);
-            setFrontMatrixPixel(1);
-            setFrontMatrixPixel(2);
-
-            // Ist
-            setFrontMatrixPixel(4);
-            setFrontMatrixPixel(5);
+            setFrontMatrixWord(0, 8, 10);
+            setFrontMatrixWord(0, 5, 6);
             break;
 
         case FrontWord::nach:
         case FrontWord::v_nach:
-            setFrontMatrixPixel(37);
-            setFrontMatrixPixel(36);
-            setFrontMatrixPixel(35);
-            setFrontMatrixPixel(34);
+            setFrontMatrixWord(3, 1, 4);
             break;
 
         case FrontWord::vor:
         case FrontWord::v_vor:
-            setFrontMatrixPixel(43);
-            setFrontMatrixPixel(42);
-            setFrontMatrixPixel(41);
-            setFrontMatrixPixel(40);
+            setFrontMatrixWord(3, 7, 10);
             break;
 
         case FrontWord::viertel:
-            setFrontMatrixPixel(28);
-            setFrontMatrixPixel(29);
-            setFrontMatrixPixel(30);
-            setFrontMatrixPixel(31);
-            setFrontMatrixPixel(32);
+            setFrontMatrixWord(2, 0, 4);
             break;
 
         case FrontWord::fuenf:
-            setFrontMatrixPixel(22);
-            setFrontMatrixPixel(23);
-            setFrontMatrixPixel(24);
-            setFrontMatrixPixel(25);
+            setFrontMatrixWord(2, 7, 10);
             break;
 
         case FrontWord::zehn:
-            setFrontMatrixPixel(14);
-            setFrontMatrixPixel(13);
-            setFrontMatrixPixel(12);
-            setFrontMatrixPixel(11);
+            setFrontMatrixWord(1, 0, 3);
             break;
 
         case FrontWord::zwanzig:
-            setFrontMatrixPixel(21);
-            setFrontMatrixPixel(20);
-            setFrontMatrixPixel(19);
-            setFrontMatrixPixel(18);
-            setFrontMatrixPixel(17);
-            setFrontMatrixPixel(16);
-            setFrontMatrixPixel(15);
+            setFrontMatrixWord(1, 4, 10);
             break;
 
         case FrontWord::halb:
-            setFrontMatrixPixel(44);
-            setFrontMatrixPixel(45);
-            setFrontMatrixPixel(46);
-            setFrontMatrixPixel(47);
+            setFrontMatrixWord(4, 7, 10);
             break;
 
         case FrontWord::h_ein:
-            setFrontMatrixPixel(51);
-            setFrontMatrixPixel(52);
-            setFrontMatrixPixel(53);
+            setFrontMatrixWord(4, 1, 3);
             break;
 
         case FrontWord::uhr:
-            setFrontMatrixPixel(109);
-            setFrontMatrixPixel(108);
-            setFrontMatrixPixel(107);
+            setFrontMatrixWord(9, 8, 10);
             break;
 
         case FrontWord::h_zwei:
-            setFrontMatrixPixel(49);
-            setFrontMatrixPixel(50);
-            setFrontMatrixPixel(51);
-            setFrontMatrixPixel(52);
+            setFrontMatrixWord(4, 2, 5);
             break;
 
         case FrontWord::h_drei:
-            setFrontMatrixPixel(61);
-            setFrontMatrixPixel(60);
-            setFrontMatrixPixel(59);
-            setFrontMatrixPixel(58);
+            setFrontMatrixWord(5, 3, 6);
             break;
 
         case FrontWord::h_vier:
-            setFrontMatrixPixel(88);
-            setFrontMatrixPixel(89);
-            setFrontMatrixPixel(90);
-            setFrontMatrixPixel(91);
+            setFrontMatrixWord(8, 7, 10);
             break;
 
         case FrontWord::h_fuenf:
-            setFrontMatrixPixel(92);
-            setFrontMatrixPixel(93);
-            setFrontMatrixPixel(94);
-            setFrontMatrixPixel(95);
+            setFrontMatrixWord(8, 3, 6);
             break;
 
         case FrontWord::h_sechs:
-            setFrontMatrixPixel(57);
-            setFrontMatrixPixel(56);
-            setFrontMatrixPixel(55);
+            setFrontMatrixWord(5, 0, 2);
             break;
 
         case FrontWord::h_sieben:
-            setFrontMatrixPixel(66);
-            setFrontMatrixPixel(67);
-            setFrontMatrixPixel(68);
-            setFrontMatrixPixel(69);
-            setFrontMatrixPixel(70);
+            setFrontMatrixWord(6, 6, 10);
             break;
 
         case FrontWord::h_acht:
-            setFrontMatrixPixel(65);
-            setFrontMatrixPixel(64);
-            setFrontMatrixPixel(63);
-            setFrontMatrixPixel(62);
+            setFrontMatrixWord(5, 7, 10);
             break;
 
         case FrontWord::h_neun:
-            setFrontMatrixPixel(70);
-            setFrontMatrixPixel(71);
-            setFrontMatrixPixel(72);
-            setFrontMatrixPixel(73);
-            setFrontMatrixPixel(74);
+            setFrontMatrixWord(6, 2, 6);
             break;
 
         case FrontWord::h_zehn:
-            setFrontMatrixPixel(80);
-            setFrontMatrixPixel(79);
-            setFrontMatrixPixel(78);
-            setFrontMatrixPixel(77);
+            setFrontMatrixWord(7, 0, 3);
             break;
 
         case FrontWord::h_elf:
-            setFrontMatrixPixel(96);
-            setFrontMatrixPixel(97);
-            setFrontMatrixPixel(98);
+            setFrontMatrixWord(8, 0, 2);
             break;
 
         case FrontWord::h_zwoelf:
-            setFrontMatrixPixel(87);
-            setFrontMatrixPixel(86);
-            setFrontMatrixPixel(85);
-            setFrontMatrixPixel(84);
-            setFrontMatrixPixel(83);
-            setFrontMatrixPixel(82);
+            setFrontMatrixWord(7, 5, 10);
             break;
 
         case FrontWord::nur:
             // Nu
-            setFrontMatrixPixel(7);
-            setFrontMatrixPixel(8);
+            setFrontMatrixWord(0, 2, 3);
             break;
 
         case FrontWord::gewesen:
             // Geweest
-            setFrontMatrixPixel(105);
-            setFrontMatrixPixel(104);
-            setFrontMatrixPixel(103);
-            setFrontMatrixPixel(102);
-            setFrontMatrixPixel(101);
-            setFrontMatrixPixel(100);
-            setFrontMatrixPixel(99);
+            setFrontMatrixWord(9, 0, 6);
             break;
 
         default:

--- a/include/Uhrtypes/Uhrtype.hpp
+++ b/include/Uhrtypes/Uhrtype.hpp
@@ -93,13 +93,10 @@ enum class FrontWord {
 
 class iUhrType {
 public:
-    virtual void setFrontMatrixPixel(const int index, bool state = true) {
-        uint8_t col, row;
-        getFrontMatrixColRow(row, col, index);
-        if (state) {
-            frontMatrix[row] |= 1UL << col;
-        } else {
-            frontMatrix[row] &= ~(1UL << col);
+    virtual void setFrontMatrixWord(const uint8_t row, const uint8_t colStart,
+                                    const uint8_t colEnd) {
+        for (uint8_t i = colStart; i <= colEnd; i++) {
+            setFrontMatrixPixel(row, i);
         }
     }
 
@@ -110,12 +107,6 @@ public:
         } else {
             frontMatrix[row] &= ~(1UL << col);
         }
-    }
-
-    virtual bool getFrontMatrixPixel(const uint16_t index) {
-        uint8_t col, row;
-        getFrontMatrixColRow(row, col, index);
-        return (frontMatrix[row] >> col) & 1U;
     }
 
     virtual bool getFrontMatrixPixel(const uint8_t row, const uint8_t col) {
@@ -152,7 +143,7 @@ public:
         uint16_t numPixelsWordMatrix = rowsWordMatrix() * colsWordMatrix();
 
         if (G.buildTypeDef == BuildTypeDef::DoubleResM1) {
-            newColsWordMatrix = 2 * colsWordMatrix() - 1; // 21
+            newColsWordMatrix = 2 * colsWordMatrix() - 1;
             numPixelsWordMatrix = rowsWordMatrix() * newColsWordMatrix;
             col *= 2;
         }
@@ -188,15 +179,6 @@ public:
             default:
                 break;
             }
-        }
-    };
-
-    virtual const void getFrontMatrixColRow(uint8_t &row, uint8_t &col,
-                                            const uint16 index) {
-        row = index / colsWordMatrix();
-        col = index % colsWordMatrix();
-        if (row % 2 == 0) {
-            col = colsWordMatrix() - 1 - col;
         }
     };
 };


### PR DESCRIPTION
Instead of indices to describe the wordclock words, a 2D description is used (row, ColStart, ColEnd). This revision saves about 2% flash.