### PR TITLE
panbachi/wordclock Layout

### DIFF
--- a/include/Uhr.h
+++ b/include/Uhr.h
@@ -247,6 +247,7 @@ enum ClockType {
     Ger10x11Nero = 11,
     Ger11x11 = 3,
     Ger11x11V2 = 8,
+    Ger11x11V3 = 14,
     Ger22x11Weather = 5,
     Ger16x8 = 13,
     Ger16x18 = 7,

--- a/include/Uhrtypes/DE11x11.v3.hpp
+++ b/include/Uhrtypes/DE11x11.v3.hpp
@@ -1,0 +1,130 @@
+#pragma once
+
+#include "DE11x11.hpp"
+
+/*
+ *           Layout Front
+ *                COL
+ *       X 9 8 7 6 5 4 3 2 1 0
+ * ROW + - - - - - - - - - - -
+ *  0  | E S K I S T L F Ü N F
+ *  1  | Z E H N Z W A N Z I G
+ *  2  | D R E I V I E R T E L
+ *  3  | T G N A C H V O R J M
+ *  4  | H A L B X Z W Ö L F P
+ *  5  | Z W E I N S I E B E N
+ *  6  | K D R E I R H F Ü N F
+ *  7  | E L F N E U N V I E R
+ *  8  | W A C H T Z E H N R S
+ *  9  | B S E C H S F M U H R
+ *  X  | E V F X R N Z S L P I
+ */
+
+class De11x11V3_t : public De11x11_t {
+public:
+    void show(FrontWord word) override {
+        switch (word) {
+
+        case FrontWord::es_ist:
+            setFrontMatrixWord(0, 9, 10);
+            setFrontMatrixWord(0, 5, 7);
+            break;
+
+        case FrontWord::viertel:
+            setFrontMatrixWord(2, 0, 6);
+            break;
+
+        case FrontWord::dreiviertel:
+            setFrontMatrixWord(2, 0, 10);
+            break;
+
+        case FrontWord::m_fuenf:
+            setFrontMatrixWord(0, 0, 3);
+            break;
+
+        case FrontWord::m_zehn:
+            setFrontMatrixWord(1, 7, 10);
+            break;
+
+        case FrontWord::m_zwanzig:
+            setFrontMatrixWord(1, 0, 6);
+            break;
+
+        case FrontWord::halb:
+            setFrontMatrixWord(4, 7, 10);
+            break;
+
+        case FrontWord::eins:
+            setFrontMatrixWord(5, 5, 8);
+            break;
+
+        case FrontWord::nach:
+        case FrontWord::v_nach:
+            setFrontMatrixWord(3, 5, 8);
+            break;
+
+        case FrontWord::vor:
+        case FrontWord::v_vor:
+            setFrontMatrixWord(3, 2, 4);
+        case FrontWord::uhr:
+            setFrontMatrixWord(9, 0, 2);
+            break;
+
+        case FrontWord::h_ein:
+            setFrontMatrixWord(5, 6, 8);
+            break;
+
+        case FrontWord::h_zwei:
+            setFrontMatrixWord(5, 7, 10);
+            break;
+
+        case FrontWord::h_drei:
+            setFrontMatrixWord(6, 6, 9);
+            break;
+
+        case FrontWord::h_vier:
+            setFrontMatrixWord(7, 0, 3);
+            break;
+
+        case FrontWord::h_fuenf:
+            setFrontMatrixWord(6, 0, 3);
+            break;
+
+        case FrontWord::h_sechs:
+            setFrontMatrixWord(9, 5, 9);
+            break;
+
+        case FrontWord::h_sieben:
+            setFrontMatrixWord(5, 0, 5);
+            break;
+
+        case FrontWord::h_acht:
+            setFrontMatrixWord(8, 6, 9);
+            break;
+
+        case FrontWord::h_neun:
+            setFrontMatrixWord(7, 4, 7);
+            break;
+
+        case FrontWord::h_zehn:
+            setFrontMatrixWord(8, 2, 5);
+            break;
+
+        case FrontWord::h_elf:
+            setFrontMatrixWord(7, 8, 10);
+            break;
+
+        case FrontWord::h_zwoelf:
+            setFrontMatrixWord(4, 1, 5);
+            break;
+
+        case FrontWord::funk:
+            break;
+
+        default:
+            break;
+        };
+    };
+};
+
+De11x11V3_t _de11x11V3;

--- a/include/clockWork.hpp
+++ b/include/clockWork.hpp
@@ -58,6 +58,8 @@ iUhrType *ClockWork::getPointer(uint8_t type) {
         return &_de11x11;
     case Ger11x11V2:
         return &_de11x11V2;
+    case Ger11x11V3:
+        return &_de11x11V3;
     case Ger22x11Weather:
         return &_de22x11Weather;
     case Ger16x8:

--- a/include/config.h
+++ b/include/config.h
@@ -36,6 +36,9 @@
 // #define DEFAULT_LAYOUT Ger11x11V2
 // 11 rows, each 11 LED's per row + 4 LED's for minutes plus twenty word
 //
+// #define DEFAULT_LAYOUT Ger11x11V3
+// 11 rows, each 11 LED's per row + 4 LED's for minutes
+//
 // #define DEFAULT_LAYOUT Ger11x11Frame
 // Same Layout as Ger11x11, but with additional LED's to illuminate the frame
 // from the side

--- a/include/config.h
+++ b/include/config.h
@@ -37,7 +37,7 @@
 // 11 rows, each 11 LED's per row + 4 LED's for minutes plus twenty word
 //
 // #define DEFAULT_LAYOUT Ger11x11V3
-// 11 rows, each 11 LED's per row + 4 LED's for minutes
+// 11 rows, each 11 LED's per row. Layout for panbachi/wordclock plate design
 //
 // #define DEFAULT_LAYOUT Ger11x11Frame
 // Same Layout as Ger11x11, but with additional LED's to illuminate the frame

--- a/webpage/index.html
+++ b/webpage/index.html
@@ -216,6 +216,7 @@
                                 <option value="11" data-i18next="view.front.de-10-11-nero"></option>
                                 <option value="3"  data-i18next="view.front.de-11-11"></option>
                                 <option value="8"  data-i18next="view.front.de-11-11-v2"></option>
+                                <option value="14"  data-i18next="view.front.de-11-11-v3"></option>
                                 <option value="5"  data-i18next="view.front.de-22-11-weather"></option>
                                 <option value="13"  data-i18next="view.front.de-16-8"></option>
                                 <option value="7"  data-i18next="view.front.de-16-18"></option>

--- a/webpage/language/de.js
+++ b/webpage/language/de.js
@@ -84,6 +84,7 @@ let TRANSLATION_DE_DE = {
 			"de-10-11-nero": "Deutsch 10 × 11 Nero",
 			"de-11-11": "Deutsch 11 × 11",
 			"de-11-11-v2": "Deutsch 11 × 11 Version 2",
+			"de-11-11-v3": "Deutsch 11 × 11 (panbachi)",
 			"de-22-11-weather": "Deutsch 10 × 11 Wetter",
 			"de-16-8": "Deutsch 16 × 8",
 			"de-16-18": "Deutsch 16 × 18",

--- a/webpage/language/en.js
+++ b/webpage/language/en.js
@@ -84,6 +84,7 @@ let TRANSLATION_EN_US = {
 			"de-10-11-nero": "German 10 × 11 Nero",
 			"de-11-11": "German 11 × 11",
 			"de-11-11-v2": "German 11 × 11 Version 2",
+			"de-11-11-v3": "German 11 × 11 (panbachi)",
 			"de-22-11-weather": "German 10 × 11 Weather",
 			"de-16-8": "German 16 × 8",
 			"de-16-18": "German 16 × 18",

--- a/webpage/language/nl.js
+++ b/webpage/language/nl.js
@@ -84,6 +84,7 @@ let TRANSLATION_NL = {
 			"de-10-11-nero": "Duits 10 × 11 Nero",
 			"de-11-11": "Duits 11 × 11",
 			"de-11-11-v2": "Duits 11 × 11 Versie 2",
+			"de-11-11-v3": "Duits 11 × 11 (panbachi)",
 			"de-22-11-weather": "Duits 10 × 11 Weer",
 			"de-16-8": "Duits 16 × 8",
 			"de-16-18": "Duits 16 × 18",


### PR DESCRIPTION
The code for the design by panbachi (https://github.com/panbachi/wordclock) unfortunately isn't maintained anymore. The layout is mostly identical with de-11-11, but the "UHR" is in a different row, and it has no "Funk" or minutes LED.  
I've added the layout so anyone following the guide by panbachi  (like me) can enjoy this Software on their clock too. I've been running a modified version of 3.0.0 the past weeks but thought it would be nice to add it to the repository for anyone to enjoy.

I haven't yet contributed to this repository, so let me know if there is anything I could do better.