### PR TITLE
Added new 'changed' parameter

### DIFF
--- a/include/Transitiontypes/Transition.h
+++ b/include/Transitiontypes/Transition.h
@@ -197,7 +197,7 @@ public:
     void demoMode(uint8_t &_minute, uint8_t _second);
     void initTransitionStart();
     bool hasMinuteChanged();
-    bool isOverwrittenByTransition(bool flag, uint8_t minute);
+    bool isOverwrittenByTransition(WordclockChanges flag, uint8_t minute);
 
     //------------------------------------------------------------------------------
     // Loop Functions

--- a/include/Transitiontypes/Transition.hpp
+++ b/include/Transitiontypes/Transition.hpp
@@ -917,20 +917,22 @@ bool Transition::hasMinuteChanged() {
 }
 
 //------------------------------------------------------------------------------
-// changesInWordMatrix: 'false' changes, e.g. color
-// changesInWordMatrix: 'true'  changes in displayed content incl. MinuteArray
+// 'WordclockChanges::Parameters', e.g. color modifications -> Apply w/o Trans
+// 'WordclockChanges::Minute', e.g. minute iterations -> Apply w/o Transition
+// 'WordclockChanges::Words', e.g. word changes -> Apply with Transition
 
-bool Transition::isOverwrittenByTransition(bool changesInWordMatrix,
+bool Transition::isOverwrittenByTransition(WordclockChanges changesInWordMatrix,
                                            uint8_t minute) {
     if (transitionType == NO_TRANSITION) {
-        if (changesInWordMatrix && hasMinuteChanged()) {
+        if (changesInWordMatrix != WordclockChanges::Parameters &&
+            hasMinuteChanged()) {
             // Needed in Case the Transition is switched off
             matrixChanged = true;
         }
     } else {
-        if (changesInWordMatrix) {
-            // Start every 5 Minutes only
-            if (minuteArray == 0) {
+        if (changesInWordMatrix != WordclockChanges::Parameters) {
+            if (changesInWordMatrix == WordclockChanges::Words ||
+                changesInWordMatrix == WordclockChanges::Layout) {
                 initTransitionStart();
             }
             lastMinute = minute;

--- a/include/Uhr.h
+++ b/include/Uhr.h
@@ -75,6 +75,14 @@ enum class SecondVariant {
     FrameSectorToggle = 3,
 };
 
+enum class WordclockChanges {
+    Null,
+    Parameters,
+    Minute,
+    Layout,
+    Words,
+};
+
 struct GLOBAL {
     uint8_t sernr;
     uint16_t prog;

--- a/include/clockWork.h
+++ b/include/clockWork.h
@@ -41,7 +41,7 @@ private:
     //------------------------------------------------------------------------------
     // Loop Helper Functions
     //------------------------------------------------------------------------------
-    bool changesInClockface();
+    WordclockChanges changesInClockface();
     void calcClockface();
     void setClock();
     void clearClockByProgInit();

--- a/include/led.h
+++ b/include/led.h
@@ -53,7 +53,7 @@ public:
     void setPixelForChar(uint8_t col, uint8_t row, uint8_t offsetCol,
                          uint8_t offsetRow, unsigned char unsigned_d1,
                          fontSize font);
-    void set(bool changed = false);
+    void set(WordclockChanges changed = WordclockChanges::Parameters);
 
     //------------------------------------------------------------------------------
     // Pixel get Functions

--- a/include/led.hpp
+++ b/include/led.hpp
@@ -347,7 +347,7 @@ void Led::setPixelForChar(uint8_t col, uint8_t row, uint8_t offsetCol,
 
 //------------------------------------------------------------------------------
 
-void Led::set(bool changed) {
+void Led::set(WordclockChanges changed) {
     setbyFrontMatrix(Foreground);
     setbyFrontMatrix(Background, false);
 


### PR DESCRIPTION
Added new 'changed' parameter for transitions to determine type of change in order to only apply transitions for changes on Wordmatrix (Now for all types of clock sizes)