### PR TITLE
Birthday

### DIFF
--- a/include/EEPROMAnything.h
+++ b/include/EEPROMAnything.h
@@ -83,6 +83,10 @@ void read() {
     Serial.print("OWM_city  : ");
     Serial.println(G.openWeatherMap.cityid);
 
+    Serial.printf("Birthday1: %02u.%02u.%04u\n",G.birthday1.day,G.birthday1.month,G.birthday1.year);
+    Serial.printf("Birthday2: %02u.%02u.%04u\n",G.birthday2.day,G.birthday2.month,G.birthday2.year);
+
+
     delay(100);
 }
 } // namespace eeprom

--- a/include/EEPROMAnything.h
+++ b/include/EEPROMAnything.h
@@ -28,6 +28,7 @@ template <class T> int readAnything(int ee, T &value) {
 void write() {
     writeAnything(0, G);
     EEPROM.commit();
+    Serial.println("Written everything to the EEPROM");
 }
 
 //------------------------------------------------------------------------------

--- a/include/Transitiontypes/Transition.h
+++ b/include/Transitiontypes/Transition.h
@@ -96,8 +96,9 @@ enum Transition_t {
     SNAKE = 10,
     // only internaly used
     RANDOM = 11,
-    COUNTDOWN = 98,
-    NEWYEAR = 99
+    BIRTHDAY = 97,
+    NEWYEAR_COUNTDOWN = 98,
+    NEWYEAR_FIRE = 99
 };
 
 enum Colorize { OFF = 0, WORDS = 1, CHARACTERS = 2 };
@@ -155,7 +156,7 @@ protected:
     void setPixelForChar(uint8_t col, uint8_t row, uint8_t offsetCol,
                          unsigned char unsigned_d1, HsbColor color);
     inline bool isIdle() { return phase == 0; }
-    bool isSilvester(Transition_t &type, struct tm &tm, bool trigger);
+    bool isSpecialEvent(Transition_t &type, struct tm &tm, bool trigger);
     Transition_t getTransitionType(bool trigger);
     bool isColorization();
     bool changeBrightness();

--- a/include/Transitiontypes/Transition.hpp
+++ b/include/Transitiontypes/Transition.hpp
@@ -52,24 +52,44 @@ Transition::~Transition() {
 }
 
 //------------------------------------------------------------------------------
+// Make special events at silvester and birthday
+//------------------------------------------------------------------------------
 
-bool Transition::isSilvester(Transition_t &type, struct tm &tm, bool trigger) {
+bool Transition::isSpecialEvent(Transition_t &type, struct tm &tm, bool trigger) {
     static uint8_t minutesAfterMidnight;
+    bool isBirthday = false;
+    bool specialEventOngoing = false;
 
-    if (trigger) {
+    if (trigger) { 
+        specialEventOngoing = (type == NEWYEAR_COUNTDOWN) || (type == NEWYEAR_FIRE) || (type == BIRTHDAY);
         // tm_mday=1..31, tm.tm_mon=0=Jan..11=Dec, tm_year=0=1900..n=1900+n
-        if ((tm.tm_mon == 11) && (tm.tm_mday == 31) && (tm.tm_hour == 23) && (tm.tm_min == 59)) {
-            minutesAfterMidnight = 0;
-            type = COUNTDOWN;
-        } else {
-            minutesAfterMidnight++;
-        }
-        if ((type == NEWYEAR) && (minutesAfterMidnight >= 11)) {
-            // switch back to standard type
-            type = getTransitionType(true);
+        isBirthday = ((tm.tm_mon+1 == G.birthday1.month) && (tm.tm_mday == G.birthday1.day)) ||
+                     ((tm.tm_mon+1 == G.birthday2.month) && (tm.tm_mday == G.birthday2.day));
+
+        if (!specialEventOngoing) { // Start only new special events when no SE is pending
+            // Conditions to start a special events 
+            if ((tm.tm_mon == 11) && (tm.tm_mday == 31) && (tm.tm_hour == 23) && (tm.tm_min == 59)) {
+                minutesAfterMidnight = 0;
+                type = NEWYEAR_COUNTDOWN; // start transition by changing transitionType
+            } else if (isBirthday && (tm.tm_min % 5 == 2)) { // Make animation 2 minutes after each clock change
+                type = BIRTHDAY; // start transition by changing transitionType
+            }
+        } else  {
+            // State machine for animation sequences
+            if (type == NEWYEAR_COUNTDOWN) {
+                type = NEWYEAR_FIRE; // after one minute countdown, switch to fireworks
+            } else if (type == NEWYEAR_FIRE) {
+                minutesAfterMidnight++;
+                if (minutesAfterMidnight >= 10) {
+                    type = getTransitionType(true); // go back to standard transition 
+                }
+            } else if (type == BIRTHDAY) {
+                type = getTransitionType(true); // after one minute go back to standard transition
+            }
         }
     }
-    return (type == COUNTDOWN) || (type == NEWYEAR);
+    specialEventOngoing = (type == NEWYEAR_COUNTDOWN) || (type == NEWYEAR_FIRE) || (type == BIRTHDAY);
+    return specialEventOngoing;
 }
 
 //------------------------------------------------------------------------------
@@ -577,9 +597,27 @@ uint16_t Transition::transitionFire() {
         sparkle = false;
         subPhase = 1;
         firework->prepare(0, _white, FIRE_1, mirrored);
-        // use current colors to be blended to act
-        copyMatrix(old, work);
-        copyMatrixFlags(work, act);
+        if (transitionType == BIRTHDAY && usedUhrType->hasHappyBirthday()) {
+            /* 
+            An einem Geburtstag wird das Feuerwerk (zum Test) alle 5 Minuten für eine Minute aktiviert (für alle Uhrentypen)
+            (Bitte den Geburtstag im WebInterface auf heute programmieren)
+            Bei Uhrentypen ohne HappyBirthday wird das Feuerwerk mit der Uhrzeit zusammen angezeigt (wie gehabt)
+            Uhrentypen die HappyBirthday unterstützen sollten hingegen folgende Anzeige haben:
+               - Urzeit wird während des Feuerwerks nicht angezeigt (ansonsten Konflikt mit den Uhr-Wörtern)
+               - Stattdessen: Feuerwerk nur mit den Wörtern "Happy Birthday"
+               - Die Urzeit ist schon entfernt ;-)
+               - Wie kann man hier die Wörter "Happy Birthday" einschalten?
+            */
+            Serial.println("Please make the Happy Birthday patch here");
+            fillMatrix(work, background);
+            //led.resetFrontMatrixBuffer();
+            //usedUhrType->show(FrontWord::happy_birthday);
+            //copyMatrix(work, act);
+        } else {
+            // use current colors to be blended to act
+            copyMatrix(old, work);
+            copyMatrixFlags(work, act);
+        }
     }
 
     bool lastSubPhase = subPhase == blendingFrames;
@@ -610,11 +648,12 @@ uint16_t Transition::transitionFire() {
         case (FIRE_6 + 4):
             mirrored = !mirrored;
             copyMatrix(old, act); // old contains artefacts
-            if ((transitionType == NEWYEAR)) {
+            if ((transitionType == NEWYEAR_FIRE) || (transitionType == BIRTHDAY)) {
+                // While NEWYEAR_FIRE or BIRTHDAY repeat transition any 500ms (will be stopped by changing transitionType)
                 transitionDelay = 500;
-                return 1; // next transition in 500ms
+                return 1; // restart transition
             }
-            return 0; // end of transition
+            return 0; // end transition
             break;
         default:
             firework->prepare(0, _white, static_cast<Icons>(phase), mirrored);
@@ -682,17 +721,18 @@ uint16_t Transition::transitionFire() {
 //------------------------------------------------------------------------------
 
 uint16_t Transition::transitionCountdown(struct tm &tm) {
-    static int8_t lastSecond = 99, countDown = 60;
-    uint8_t _second = tm.tm_sec; // 0 - 59
+    static int8_t lastSecond = 0, countDown = 59;
+    uint8_t _second = tm.tm_sec; // 0..59
     if (_second != lastSecond) {
-        if (phase == 1) {
+        if (phase == 1) { // Initialize at start of animation
             transitionDelay = 50;
+            lastSecond = 0;
+            countDown = 59;
         }
-        if (countDown < 0) { // 60 - 0
-            countDown = 60;
-            lastSecond = 99;
-            transitionType = NEWYEAR;
-            return 1; // continue FIRE in phase 1
+        if (countDown < 0) { // Countdown finished?
+            lastSecond = 0;
+            countDown = 59;
+            return 0;
         }
         lastSecond = _second;
         fillMatrix(work, background);
@@ -903,6 +943,13 @@ void Transition::initTransitionStart() {
 }
 
 //------------------------------------------------------------------------------
+// TODO: This function is used in two different functions:
+// 1) Transition::isOverwrittenByTransition
+// 2) Transition::loop
+// It looks like that it is intended that function 1 and 2 both can reset the 
+// "MinuteChanged" status, so that only the first function calling the 
+// Transition::hasMinuteChanged is executed!?
+// Are there better implementations which are more obvious?
 
 bool Transition::hasMinuteChanged() {
     if (lastMinute != _minute) {
@@ -919,10 +966,10 @@ bool Transition::hasMinuteChanged() {
 
 bool Transition::isOverwrittenByTransition(WordclockChanges changesInWordMatrix,
                                            uint8_t minute) {
-    if (transitionType == NO_TRANSITION) {
+        if (transitionType == NO_TRANSITION) {
         if (changesInWordMatrix != WordclockChanges::Parameters &&
             hasMinuteChanged()) {
-            // Needed in Case the Transition is switched off
+                        // Needed in Case the Transition is switched off
             matrixChanged = true;
         }
     } else {
@@ -956,30 +1003,24 @@ void Transition::loop(struct tm &tm) {
     }
 
     if (G.prog == COMMAND_IDLE || G.prog == COMMAND_MODE_WORD_CLOCK) {
-        if (!isSilvester(transitionType, tm, hasMinuteChanged())) {
+        if (!isSpecialEvent(transitionType, tm, hasMinuteChanged())) {
             transitionType = getTransitionType(hasMinuteChanged());
         }
-
-        if (transitionType == NO_TRANSITION) {
-            if (lastTransitionType != NO_TRANSITION) {
-                lastTransitionType = NO_TRANSITION;
-                copyMatrix(work, act);
-                colorize(work);
-                copy2Stripe(work);
-                led.show();
-            }
-        } else {
+        if (transitionType != NO_TRANSITION) {
             if (changesInTransitionTypeDurationOrDemo()) {
                 lastTransitionType = transitionType;
                 lastTransitionDemo = G.transitionDemo;
                 lastTransitionDuration = G.transitionDuration;
+                copyMatrix(work, act);
+                colorize(work);
+                copy2Stripe(work);
+                led.show();
                 phase = 1;
             }
             if (G.transitionColorize != lastTransitionColorize) {
                 lastTransitionColorize = G.transitionColorize;
                 colorize(isIdle() ? work : act);
             }
-
             uint32_t now = millis();
             if ((!isIdle()) && (now >= nextActionTime)) {
                 nextActionTime = now + transitionDelay;
@@ -1010,14 +1051,15 @@ void Transition::loop(struct tm &tm) {
                 case BALLS:
                     phase = transitionBalls();
                     break;
-                case NEWYEAR:
+                case BIRTHDAY:
+                case NEWYEAR_FIRE:
                 case FIRE:
                     phase = transitionFire();
                     break;
                 case SNAKE:
                     phase = transitionSnake();
                     break;
-                case COUNTDOWN:
+                case NEWYEAR_COUNTDOWN:
                     phase = transitionCountdown(tm);
                     break;
                 case RANDOM:
@@ -1027,7 +1069,6 @@ void Transition::loop(struct tm &tm) {
             }
             transitionColorChange();
             copy2Stripe(work);
-            setMinute(); // TODO: Is setMinute() on the right place ?
             led.show();
         }
     }

--- a/include/Transitiontypes/Transition.hpp
+++ b/include/Transitiontypes/Transition.hpp
@@ -57,19 +57,15 @@ bool Transition::isSilvester(Transition_t &type, struct tm &tm, bool trigger) {
     static uint8_t minutesAfterMidnight;
 
     if (trigger) {
-#if 1
-        if ((tm.tm_mon == 12) && (tm.tm_mday == 31) && (tm.tm_hour == 23) &&
-            (tm.tm_min == 59))
-#else
-        if (tm.tm_min == G.autoLdrBright) // for testing
-#endif
-        {
+        // tm_mday=1..31, tm.tm_mon=0=Jan..11=Dec, tm_year=0=1900..n=1900+n
+        if ((tm.tm_mon == 11) && (tm.tm_mday == 31) && (tm.tm_hour == 23) && (tm.tm_min == 59)) {
             minutesAfterMidnight = 0;
             type = COUNTDOWN;
         } else {
             minutesAfterMidnight++;
         }
         if ((type == NEWYEAR) && (minutesAfterMidnight >= 11)) {
+            // switch back to standard type
             type = getTransitionType(true);
         }
     }
@@ -77,7 +73,7 @@ bool Transition::isSilvester(Transition_t &type, struct tm &tm, bool trigger) {
 }
 
 //------------------------------------------------------------------------------
-
+// Get configured transition type: Random or Fix type
 Transition_t Transition::getTransitionType(bool trigger) {
     if (G.transitionType == RANDOM) {
         if (trigger) {
@@ -686,7 +682,7 @@ uint16_t Transition::transitionFire() {
 //------------------------------------------------------------------------------
 
 uint16_t Transition::transitionCountdown(struct tm &tm) {
-    static uint8_t lastSecond = 99, countDown = 60;
+    static int8_t lastSecond = 99, countDown = 60;
     uint8_t _second = tm.tm_sec; // 0 - 59
     if (_second != lastSecond) {
         if (phase == 1) {

--- a/include/Uhr.h
+++ b/include/Uhr.h
@@ -50,6 +50,12 @@ enum class WhiteType {
     ColdWhite = 2,
 };
 
+struct Birthday {
+    uint8_t day;
+    uint8_t month;
+    uint16_t year;
+};
+
 struct OpenWeatherMapData {
     char apikey[35];
     char cityid[8];
@@ -133,6 +139,8 @@ struct GLOBAL {
     bool bootLedSweep;
     bool bootShowWifi;
     bool bootShowIP;
+    Birthday birthday1;
+    Birthday birthday2;
 };
 GLOBAL G = {};
 
@@ -211,7 +219,7 @@ enum CommandWords {
 
     COMMAND_SET_INITIAL_VALUES = 20,
     COMMAND_SET_TIME = 30,
-
+    COMMAND_SET_BIRTHDAYS = 83,
     COMMAND_SET_LANGUAGE_VARIANT = 84,
     COMMAND_SET_MQTT = 85,
     COMMAND_SET_TIME_MANUAL = 86,
@@ -244,6 +252,7 @@ enum CommandWords {
     COMMAND_REQUEST_AUTO_LDR = 203,
     COMMAND_REQUEST_TRANSITION = 204,
     COMMAND_REQUEST_MQTT_VALUES = 205,
+    COMMAND_REQUEST_BIRTHDAYS = 206,
 
     PLACEHOLDER_MAX_REQUEST = 255,
 };

--- a/include/Uhrtypes/DE10x11.alternative.hpp
+++ b/include/Uhrtypes/DE10x11.alternative.hpp
@@ -84,10 +84,8 @@ public:
             break;
 
         case FrontWord::happy_birthday:
-            // happy
-            setFrontMatrixWord(3, 3, 7);
-            // happy
-            setFrontMatrixWord(4, 0, 7);
+            setFrontMatrixWord(3, 3,  7); // Happy
+            setFrontMatrixWord(4, 3, 10); // Birthday
             break;
 
         case FrontWord::hour_1:

--- a/include/Uhrtypes/DE10x11.alternative.hpp
+++ b/include/Uhrtypes/DE10x11.alternative.hpp
@@ -29,6 +29,7 @@ public:
     //------------------------------------------------------------------------------
 
     virtual const bool hasDreiviertel() override { return true; }
+    virtual const bool hasHappyBirthday() override { return true; }
 
     //------------------------------------------------------------------------------
 

--- a/include/Uhrtypes/Uhrtype.hpp
+++ b/include/Uhrtypes/Uhrtype.hpp
@@ -185,6 +185,8 @@ public:
 
     virtual const bool has24HourLayout() { return false; }
 
+    virtual const bool hasHappyBirthday() { return false; }
+
     virtual const bool hasWeatherLayout() { return false; }
 
     virtual const bool hasSecondsFrame() { return false; }

--- a/include/clockWork.hpp
+++ b/include/clockWork.hpp
@@ -1012,7 +1012,7 @@ void ClockWork::loop(struct tm &tm) {
     case COMMAND_REQUEST_BIRTHDAYS: {
         DynamicJsonDocument config(1024);
         config["command"] = "birthdays";
-        char dateString[10];
+        char dateString[14];
         sprintf (dateString, "%04u-%02u-%02u", G.birthday1.year, G.birthday1.month, G.birthday1.day);
         config["birthdaysDate1"] = dateString;
         sprintf (dateString, "%04u-%02u-%02u", G.birthday2.year, G.birthday2.month, G.birthday2.day);

--- a/include/clockWork.hpp
+++ b/include/clockWork.hpp
@@ -1001,6 +1001,23 @@ void ClockWork::loop(struct tm &tm) {
         config["hasSecondsFrame"] = usedUhrType->hasSecondsFrame();
         config["hasMinuteInWords"] = usedUhrType->hasMinuteInWords();
         config["numOfRows"] = usedUhrType->rowsWordMatrix();
+
+        serializeJson(config, str);
+        Serial.print("Sending Payload:");
+        Serial.println(str);
+        webSocket.sendTXT(G.client_nr, str, strlen(str));
+        break;
+    }
+
+    case COMMAND_REQUEST_BIRTHDAYS: {
+        DynamicJsonDocument config(1024);
+        config["command"] = "birthdays";
+        char dateString[10];
+        sprintf (dateString, "%04u-%02u-%02u", G.birthday1.year, G.birthday1.month, G.birthday1.day);
+        config["birthdaysDate1"] = dateString;
+        sprintf (dateString, "%04u-%02u-%02u", G.birthday2.year, G.birthday2.month, G.birthday2.day);
+        config["birthdaysDate2"] = dateString;
+
         serializeJson(config, str);
         Serial.print("Sending Payload:");
         Serial.println(str);
@@ -1078,7 +1095,7 @@ void ClockWork::loop(struct tm &tm) {
         parametersChanged = true;
         break;
     }
-
+    case COMMAND_SET_BIRTHDAYS:
     case COMMAND_SET_MINUTE:
     case COMMAND_SET_BRIGHTNESS:
     case COMMAND_SET_AUTO_LDR:

--- a/include/webPageAdapter.h
+++ b/include/webPageAdapter.h
@@ -111,8 +111,9 @@ WebPageAdapter webSocket = WebPageAdapter(80);
 //------------------------------------------------------------------------------
 
 uint16_t split(uint8_t *payload, uint8_t start, uint8_t length = 3) {
-    char buffer[length];
-    uint8_t m = 0;
+    // char buffer[length];
+    char buffer[4] = {'0','0','0','0'};
+    uint8_t m = 4-length;
     for (uint16_t k = start; k < (start + length); k++) {
         buffer[m] = payload[k];
         m++;
@@ -428,6 +429,20 @@ void webSocketEvent(uint8_t num, WStype_t type, uint8_t *payload,
             break;
         }
 
+
+            //------------------------------------------------------------------------------
+
+        case COMMAND_SET_BIRTHDAYS: {
+            G.birthday1.year = split(payload, 3, 4);
+            G.birthday1.month = split(payload, 8, 2);
+            G.birthday1.day = split(payload, 11, 2);
+            G.birthday2.year = split(payload, 13, 4);
+            G.birthday2.month = split(payload, 18, 2);
+            G.birthday2.day = split(payload, 21, 2);
+            Serial.println("Birthday dates set to: ");
+            Serial.printf("Birthday1: %02u.%02u.%04u\n",G.birthday1.day,G.birthday1.month,G.birthday1.year);
+            Serial.printf("Birthday2: %02u.%02u.%04u\n",G.birthday2.day,G.birthday2.month,G.birthday2.year);
+        }
             //------------------------------------------------------------------------------
 
         case COMMAND_SET_COLORTYPE: {
@@ -538,6 +553,7 @@ void webSocketEvent(uint8_t num, WStype_t type, uint8_t *payload,
             //------------------------------------------------------------------------------
 
         case COMMAND_REQUEST_MQTT_VALUES:
+        case COMMAND_REQUEST_BIRTHDAYS:
         case COMMAND_REQUEST_CONFIG_VALUES:
         case COMMAND_REQUEST_COLOR_VALUES:
         case COMMAND_REQUEST_WIFI_LIST:

--- a/src/Wortuhr.cpp
+++ b/src/Wortuhr.cpp
@@ -212,6 +212,12 @@ void setup() {
         G.transitionSpeed = 30;
         G.transitionColorize = 1;
         G.transitionDemo = false;
+        G.birthday1.day = 1;
+        G.birthday1.month = 1;
+        G.birthday1.year = 500;
+        G.birthday2.day = 1;
+        G.birthday2.month = 1;
+        G.birthday2.year = 500;
 
         eeprom::write();
         Serial.println("eeprom schreiben");
@@ -375,7 +381,7 @@ void setup() {
 
 void loop() {
     time_t utc = time(nullptr);
-    struct tm tm;
+    struct tm tm; // tm_mday=1..31, tm.tm_mon=0=Jan..11=Dec, tm_year=0=1900..n=1900+n
     localtime_r(&utc, &tm);
     if (utc > 100000000) {
         _second = tm.tm_sec;

--- a/webpage/index.html
+++ b/webpage/index.html
@@ -54,6 +54,7 @@
                 <li class="pure-menu-item" role="none"><a href="#" class="pure-menu-link" role="menuitem" data-navigation="frontoptions" data-i18next="view.h1"></a></li>
                 <li class="pure-menu-item" role="none"><a href="#" class="pure-menu-link" role="menuitem" data-navigation="settings" data-i18next="settings.h1"></a></li>
                 <li class="pure-menu-item" role="none"><a href="#" class="pure-menu-link" role="menuitem" data-navigation="smart-home" data-i18next="smart-home.h1"></a></li>
+                <li class="pure-menu-item" role="none"><a href="#" class="pure-menu-link" role="menuitem" data-navigation="birthdays" data-i18next="birthdays.h1"></a></li>
                 <li class="pure-menu-item" role="none"><a href="#" class="pure-menu-link" role="menuitem" data-navigation="about" data-i18next="about.h1"></a></li>
 
                 <li class="pure-menu-heading" role="none"><label for="language" data-i18next="menu.language.label"></label></li>
@@ -643,6 +644,30 @@
                         <div class="pure-controls">
                             <button id="initial-values-button" class="pure-button" data-i18next="settings.restart.restart"></button>
                             <button id="reset-button" class="pure-button" data-i18next="settings.restart.reset"></button>
+                        </div>
+                    </form>
+                </div>
+            </section>
+
+            <section class="pure-u-24-24 section section-birthdays">
+                <header class="header">
+                    <svg aria-hidden="true"><use href="#eye"/></svg>
+                    <h1 data-i18next="birthdays.h1"></h1>
+                </header>
+                <div class="box">
+                    <h2 data-i18next="birthdays.dates.h2"></h2>
+                    <p data-i18next="birthdays.dates.help"></p>
+                    <form class="pure-form pure-form-aligned">
+                        <div class="pure-control-group">
+                            <label for="birthdays-date1" data-i18next="birthdays.dates.date1.label"></label>
+                            <input type="date" id="birthdays-date1" required>
+                        </div>
+                        <div class="pure-control-group">
+                            <label for="birthdays-date2" data-i18next="birthdays.dates.date2.label"></label>
+                            <input type="date" id="birthdays-date2" required>
+                        </div>
+                        <div class="pure-controls">
+                            <button id="birthdays-store-button" class="pure-button" data-i18next="birthdays.dates.save"></button>
                         </div>
                     </form>
                 </div>

--- a/webpage/language/de.js
+++ b/webpage/language/de.js
@@ -165,7 +165,23 @@ let TRANSLATION_DE_DE = {
 			"ip-address": "IP-Adresse anzeigen"
 		}
 	},
-
+	"birthdays": {
+		"h1": "Geburtstage",
+		"dates": {
+			"h2": "Termine",
+			"help": "Die Uhr kann an Geburtstagen auf eine spezielle Anzeige wechseln:\n" +
+					"Bei allen Uhrentypen wird jede volle Stunde eine Feuerwerk-Animation gestartet.\n" +
+					"Unterstützt der gewählte Uhrentypus die Wörter „Happy Birthday“, dann werden diese den ganzen Tag erleuchtet.\n\n" +
+					"Geburtstage vor dem Jahr 1000 werden ignoriert.",
+			"save": "Speichern",
+			"date1": {
+				"label": "Termin 1:"
+			},
+			"date2": {
+				"label": "Termin 2:"
+			}
+		}
+	},
 	"settings": {
 		"h1": "Einstellungen",
 		"status": {

--- a/webpage/language/de.js
+++ b/webpage/language/de.js
@@ -169,10 +169,9 @@ let TRANSLATION_DE_DE = {
 		"h1": "Geburtstage",
 		"dates": {
 			"h2": "Termine",
-			"help": "Die Uhr kann an Geburtstagen auf eine spezielle Anzeige wechseln:\n" +
-					"Bei allen Uhrentypen wird jede volle Stunde eine Feuerwerk-Animation gestartet.\n" +
-					"Unterstützt der gewählte Uhrentypus die Wörter „Happy Birthday“, dann werden diese den ganzen Tag erleuchtet.\n\n" +
-					"Geburtstage vor dem Jahr 1000 werden ignoriert.",
+			"help": "An Geburtstagen erscheint alle 5 Minuten eine Feuerwerk-Animation.\n" +
+					"Bei kompatiblen Uhrentypen werden während der Animation die Wörter „Happy Birthday“ statt der Uhrzeit angezeigt.\n" +
+					"Geburtstage vor dem Jahr 1900 werden nicht animiert.\n",
 			"save": "Speichern",
 			"date1": {
 				"label": "Termin 1:"
@@ -256,11 +255,12 @@ let TRANSLATION_DE_DE = {
 		},
 		"wifi": {
 			"h2": "Wi-Fi / WLAN",
-			"help": "Neukonfiguration erstellt ein eigenes WLAN.\n" +
-				"Mit diesem verbinden, dann kann das Zielnetz ausgewählt werden.",
+			"help": "Eine Rekonfiguration der WLAN Verbindung ist nur über den WIFI Accesspoint der Wortuhr möglich.\n" +
+				"Durch Drücken der Taste RESET werden die WLAN Verbindungsdaten gelöscht und in den WIFI Accesspoint Modus gewechselt.\n" +
+				"Der WIFI Accesspoint ist jetzt erreichbar unter dem Netzwerknamen Connect_to_Wordclock.",
 			"ssid": "WLAN-Name (SSID)",
-			"other-wifi": "Anderes WLAN",
-			"configure": "Konfigurieren",
+			"other-wifi": "WLAN",
+			"configure": "Reset",
 			"until-restart": "Bis zum Neustart",
 			"deactivate": "Ausschalten"
 		},

--- a/webpage/language/en.js
+++ b/webpage/language/en.js
@@ -169,10 +169,9 @@ let TRANSLATION_EN_US = {
 		"h1": "Birthdays",
 		"dates": {
 			"h2": "Appointments",
-			"help": "The clock can switch to special appearance on birthdays:\n" +
-					"A fireworks animation starts every hour at all clock types.\n" +
-					"If the used clock type supports the words “Happy Birthday”, they will be illuminated all day long.\n\n" +
-					"Birthdays before the year 1000 are ignored.",
+			"help": "On birthdays, a fireworks animation appears every 5 minutes.\n" +
+					"Compatible clock types will display the words “Happy Birthday” instead of the time during the animation.\n" +
+					"Birthdays before 1900 are not animated.",
 			"save": "Save",
 			"date1": {
 				"label": "Date 1:"
@@ -256,11 +255,12 @@ let TRANSLATION_EN_US = {
 		},
 		"wifi": {
 			"h2": "Wi-Fi",
-			"help": "Reconfiguration creates its own wireless network.\n " +
-				"Connect to this temporary network, then the target network can be selected.",
+			"help": "A reconfiguration of the WLAN connection is only possible via the WIFI access point of the word clock.\n " +
+			"By pressing the RESET button, the WLAN connection data is deleted and the device switches to WIFI access point mode.\n " +
+			"The WIFI access point can now be reached under the network name Connect_to_Wordclock.",
 			"ssid": "Wi-Fi Name (SSID)",
-			"other-wifi": "Other Wi-Fi",
-			"configure": "Configure",
+			"other-wifi": "WLAN",
+			"configure": "Reset",
 			"until-restart": "Until Restart",
 			"deactivate": "Deactivate"
 		},

--- a/webpage/language/en.js
+++ b/webpage/language/en.js
@@ -165,7 +165,23 @@ let TRANSLATION_EN_US = {
 			"ip-address": "Show IP Address"
 		}
 	},
-
+	"birthdays": {
+		"h1": "Birthdays",
+		"dates": {
+			"h2": "Appointments",
+			"help": "The clock can switch to special appearance on birthdays:\n" +
+					"A fireworks animation starts every hour at all clock types.\n" +
+					"If the used clock type supports the words “Happy Birthday”, they will be illuminated all day long.\n\n" +
+					"Birthdays before the year 1000 are ignored.",
+			"save": "Save",
+			"date1": {
+				"label": "Date 1:"
+			},
+			"date2": {
+				"label": "Date 2:"
+			}
+		}
+	},
 	"settings": {
 		"h1": "Settings",
 		"status": {

--- a/webpage/script.js
+++ b/webpage/script.js
@@ -125,6 +125,7 @@ MODE_TO_INPUT_ID.set(COMMAND_MODE_TRANSITION, "mode-wordclock");
 // other commands
 var COMMAND_SET_INITIAL_VALUES = 20;
 var COMMAND_SET_TIME = 30;
+var COMMAND_SET_BIRTHDAYS = 83;
 var COMMAND_SET_LANGUAGE_VARIANT = 84;
 var COMMAND_SET_MQTT = 85;
 var COMMAND_SET_TIME_MANUAL = 86;
@@ -155,6 +156,7 @@ var COMMAND_REQUEST_WIFI_LIST = 202;
 var COMMAND_REQUEST_AUTO_LDR = 203;
 var COMMAND_REQUEST_TRANSITION = 204;
 var COMMAND_REQUEST_MQTT_VALUES = 205;
+var COMMAND_REQUEST_BIRTHDAYS = 206;
 
 // colors
 var COLOR_FOREGROUND = 0;
@@ -333,6 +335,11 @@ function initWebsocket() {
 			$("#mqtt-pass").set("value", data.MQTT_Pass);
 			$("#mqtt-clientid").set("value", data.MQTT_ClientId);
 			$("#mqtt-topic").set("value", data.MQTT_Topic);
+		}
+
+		if (data.command === "birthdays") {
+			$("#birthdays-date1").set("value", data.birthdaysDate1);
+			$("#birthdays-date2").set("value", data.birthdaysDate2);
 		}
 
 		if (data.command === "config") {
@@ -692,6 +699,9 @@ $.ready(function() {
 		if (navigation === "frontoptions") {
 			sendCmd(COMMAND_REQUEST_CONFIG_VALUES);
 		}
+		if (navigation === "birthdays") {
+			sendCmd(COMMAND_REQUEST_BIRTHDAYS);
+		}
 		if (navigation === "settings" || navigation === "frontoptions") {
 			sendCmd(COMMAND_REQUEST_CONFIG_VALUES);
 			sendCmd(COMMAND_REQUEST_AUTO_LDR);
@@ -917,6 +927,9 @@ $.ready(function() {
 	});
 	$("#reset-button").on("click", function() {
 		sendCmd(COMMAND_RESET);
+	});
+	$("#birthdays-store-button").on("click", function() {
+		sendCmd(COMMAND_SET_BIRTHDAYS, getPaddedString($("#birthdays-date1").get("value"), 10) + getPaddedString($("#birthdays-date2").get("value"), 10));
 	});
 	$("#uhrzeit-button").on("click", function() {
 


### PR DESCRIPTION
Hallo @dbambus,
Der pull request bezieht sich auf den Issue "Geburtstage auf Webseite eingeben"

Ich benutze die Uhrenvariante „DE 10x11 Alternativer Rahmen“ (class De10x11AlternativeFrame_t).
Diese Uhrenvariante kann den Text "Happy Birthday" anzeigen.
Diese Feature wird noch nicht von der Software unterstützt.

Daher habe ich folgendes implementiert:
1. Eingabemöglichkeit von zwei Geburtstagen im WebInterface
2. Die Animation:
An einem Geburtstag wird das Feuerwerk (zum Test) alle 5 Minuten für eine Minute aktiviert (für alle Uhrentypen)
(Bitte einen Geburtstag im WebInterface auf den heutigen Tag programmieren)
Bei Uhrentypen ohne die Wörter "Happy Birthday" wird das Feuerwerk mit der Uhrzeit zusammen angezeigt 
Uhrentypen die "Happy Birthday" unterstützen sollten hingegen folgende Anzeige haben:
- Uhrzeit wird während des Feuerwerks nicht angezeigt (ansonsten Konflikt mit den Uhr-Wörtern)
- Stattdessen: Feuerwerk nur mit den Wörtern "Happy Birthday"
  - leider habe ich keine gute Lösung gefunden, die Wörter "Happy Birthday" einzuschalten
     - Die Urzeit ist schon entfernt ;-)
     - Wie kann man hier die Wörter "Happy Birthday" einschalten?
Die relevante Stelle im Code ist: Transition.hpp, Zeile 602ff

Kannst du das Problem lösen?

Vielen Dank und Grüße
  Stefan 
