### PR TITLE
Enable AP mode if there is no WiFi.

### DIFF
--- a/include/Wifi.hpp
+++ b/include/Wifi.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "nowifi.hpp" 
 
 //---------------------------------------------------------
 // WLAN-Status
@@ -56,6 +57,7 @@ void WiFiEvent(WiFiEvent_t event) {
         break;
     case WIFI_EVENT_STAMODE_DISCONNECTED:
         Serial.println("WiFi lost connection");
+        enableAPAfterDelay();
         break;
     default:
         break;

--- a/include/nowifi.hpp
+++ b/include/nowifi.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <WiFiManager.h>
+
+void enableAPAfterDelay() {
+    static bool apEnabled = false;
+    static unsigned long startTime = 0;
+    const unsigned long delayDuration = 5 * 60 * 1000; // 5 Minuten in Millisekunden
+
+    if (!apEnabled) {
+        if (startTime == 0) {
+            startTime = millis(); // Speichere den Startzeitpunkt, wenn noch nicht geschehen
+        }
+
+        if (millis() - startTime >= delayDuration) {
+            // Wenn die Zeit abgelaufen ist, schalte den Access Point ein
+            WiFi.enableAP(true);
+            Serial.println("Enabled Access Point (AP) mode due to no WiFi connection within 5 minutes.");
+            apEnabled = true; 
+        }
+    }
+}


### PR DESCRIPTION
Wenn die aktuelle WLAN-SSID nach einem Neustart nicht gefunden wird, wird der AP-Modus auf aktiv gesetzt.
Dies ermöglicht es, die WLAN-Einstellungen neu zu konfigurieren. Neu flashen oder Zurücksetzen ist nicht mehr nötig.