### PR TITLE
Corrections for French and Romanian time display

### DIFF
--- a/include/Uhrtypes/FR10x11.hpp
+++ b/include/Uhrtypes/FR10x11.hpp
@@ -27,7 +27,7 @@ public:
 
     //------------------------------------------------------------------------------
 
-    // virtual const bool hasZwanzig() override { return true; }
+    virtual const bool hasZwanzig() override { return true; }
 
     //------------------------------------------------------------------------------
 

--- a/include/clockWork.hpp
+++ b/include/clockWork.hpp
@@ -549,7 +549,9 @@ void ClockWork::setMinute(uint8_t min, uint8_t &offsetHour, bool &fullHour) {
             usedUhrType->show(FrontWord::nach);
             break;
         case 20:
-            if (hasTwentyAndCheckForUsage()) {
+            if (hasTwentyAndCheckForUsage() && G.UhrtypeDef == Fr10x11) {
+                usedUhrType->show(FrontWord::min_20);
+                } else if (hasTwentyAndCheckForUsage() && G.UhrtypeDef != Fr10x11) {
                 usedUhrType->show(FrontWord::min_20);
                 usedUhrType->show(FrontWord::nach);
             } else {
@@ -564,7 +566,9 @@ void ClockWork::setMinute(uint8_t min, uint8_t &offsetHour, bool &fullHour) {
         case 23:
         case 24:
         case 25:
-            if (usedUhrType->hasTwentyfive()) {
+            if (usedUhrType->hasTwentyfive()&& G.UhrtypeDef == Fr10x11) {
+                usedUhrType->show(FrontWord::min_25);
+                } else if (usedUhrType->hasTwentyfive() && G.UhrtypeDef != Fr10x11) {
                 usedUhrType->show(FrontWord::min_25);
                 usedUhrType->show(FrontWord::nach);
             } else {
@@ -620,12 +624,13 @@ void ClockWork::setMinute(uint8_t min, uint8_t &offsetHour, bool &fullHour) {
             } else if (usedUhrType->hasTwentyfive()) {
                 usedUhrType->show(FrontWord::min_25);
                 usedUhrType->show(FrontWord::vor);
+                offsetHour = 1;
             } else {
                 usedUhrType->show(FrontWord::min_5);
                 usedUhrType->show(FrontWord::nach);
                 usedUhrType->show(FrontWord::halb);
+                offsetHour = 1;
             }
-            offsetHour = 1;
             break;
         case 36:
         case 37:


### PR DESCRIPTION
In the French edition, the "nach" has been removed for "20 nach" and "25 nach" because it is not needed in either case. Correction of the "offsetHour" for "case 35". It showed an hour too early if the "hasThirtyfive" is set.

In der französischen Sprachausgabe darf das «ET»(NACH) bei 20 und 25 Minuten nicht angezeigt werden. «IL EST UNE HEURE ET VINGT» ist falsch. Richtig ist «IL EST UNE HEURE VINGT». Ich habe mit meinen sehr bescheidenen Programmierkenntnisen das probiert zu beheben. Eventuell kommt man auch eleganter zum gleichen Ziel ;-)

Dann ist mir im Fall wo «hasThirtyfive» mit true bewertet ist (rumänische Anzeige) aufgefallen, dass bei einer Uhrzeit z.B. 9:35 die Anzeige 10:35 anzeigt. Hier mussten nur die «offsetHour» richtig plaziert werden. Nun gibt die Anzeige auch 9:35 Uhr aus.

Vielen Dank für die tolle Arbeit hier!