### PR TITLE
Add: ESP32-C3 to the supported boards. 

### DIFF
--- a/include/clockWork.hpp
+++ b/include/clockWork.hpp
@@ -7,6 +7,8 @@
 #include <Arduino.h>
 #include <BH1750.h>
 
+#define LEDGPIO 27
+
 OpenWMap weather;
 BH1750 lightMeter(0x23);
 
@@ -161,8 +163,7 @@ void ClockWork::initLedStrip(uint8_t num) {
             strip_RGBW = new NeoPixelBus<NeoGrbwFeature, Neo800KbpsMethod>(500);
 #elif defined(ESP32)
             strip_RGBW =
-                new NeoPixelBus<NeoGrbwFeature, NeoEsp32I2s1X8Sk6812Method>(500,
-                                                                            27);
+                new NeoPixelBus<NeoGrbwFeature, NeoSk6812Method>(500, LEDGPIO);
 #endif
             strip_RGBW->Begin();
         }
@@ -177,8 +178,7 @@ void ClockWork::initLedStrip(uint8_t num) {
             strip_RGB = new NeoPixelBus<NeoMultiFeature, Neo800KbpsMethod>(500);
 #elif defined(ESP32)
             strip_RGB =
-                new NeoPixelBus<NeoMultiFeature, NeoEsp32I2s1X8Ws2812xMethod>(
-                    500, 27);
+                new NeoPixelBus<NeoMultiFeature, NeoWs2812xMethod>(500, LEDGPIO);
 #endif
             strip_RGB->Begin();
         }

--- a/include/clockWork.hpp
+++ b/include/clockWork.hpp
@@ -177,8 +177,8 @@ void ClockWork::initLedStrip(uint8_t num) {
 #ifdef ESP8266
             strip_RGB = new NeoPixelBus<NeoMultiFeature, Neo800KbpsMethod>(500);
 #elif defined(ESP32)
-            strip_RGB =
-                new NeoPixelBus<NeoMultiFeature, NeoWs2812xMethod>(500, LEDGPIO);
+            strip_RGB = new NeoPixelBus<NeoMultiFeature, NeoWs2812xMethod>(
+                500, LEDGPIO);
 #endif
             strip_RGB->Begin();
         }

--- a/platformio.ini
+++ b/platformio.ini
@@ -50,3 +50,25 @@ lib_deps =
     https://github.com/tzapu/WiFiManager#v2.0.17
     claws/BH1750@^1.3.0
 extra_scripts = pre:extra_scripts.py
+
+[env:esp32c3dev]
+platform = espressif32
+board = esp32-c3-devkitc-02
+board_build.partitions = partitions_singleapp_large.csv
+framework = arduino
+upload_speed = 921600
+monitor_speed = 460800
+build_flags = 
+    -Os
+    -ffunction-sections
+    -fdata-sections
+    -Wl,--gc-sections
+lib_deps =
+    makuna/NeoPixelBus@^2.7.6
+    bblanchon/ArduinoJson@^6.17.2
+    links2004/WebSockets@2.4.1
+    adafruit/RTClib@^1.11.2
+    knolleary/PubSubClient@^2.8.0
+    https://github.com/tzapu/WiFiManager#v2.0.17
+    claws/BH1750@^1.3.0
+extra_scripts = pre:extra_scripts.py

--- a/src/Wortuhr.cpp
+++ b/src/Wortuhr.cpp
@@ -35,8 +35,8 @@ iUhrType *usedUhrType = nullptr;
 NeoPixelBus<NeoMultiFeature, Neo800KbpsMethod> *strip_RGB = NULL;
 NeoPixelBus<NeoGrbwFeature, Neo800KbpsMethod> *strip_RGBW = NULL;
 #elif defined(ESP32)
-NeoPixelBus<NeoGrbwFeature, NeoEsp32I2s1X8Sk6812Method> *strip_RGBW = NULL;
-NeoPixelBus<NeoMultiFeature, NeoEsp32I2s1X8Ws2812xMethod> *strip_RGB = NULL;
+NeoPixelBus<NeoGrbwFeature, NeoSk6812Method> *strip_RGBW = NULL;
+NeoPixelBus<NeoMultiFeature, NeoWs2812xMethod> *strip_RGB = NULL;
 #endif
 
 WiFiClient client;


### PR DESCRIPTION
Hello,

Today I tried to use another ESP32 board, because as I read the ESP32-C3 is the cheaper replacement for the ESP8266 when this has reached its EOL in 2029. It worked surprisingly well. I had to modify the following parts:

- Add: the `esp32c3dev` environment.
- Mod: the NeoPixel method which gets used for the LEDs, because as far as I have seen in the code this is a universal method it could also work with the ESP8266, but this has to be confirmed.
- Add: a simple and easy definition of the `LEDGPIO` for convenience, to change the pins for the different ESPs. I also suggest that this gets done in a more universal way in the `Wortuhr.cpp` for all the periphery. I don't like the magic values in the code for the GPIOs.

I have tested the code with an ESP32 DevKit v1 (ESP32 Wroom 32) and an official ESP32-C3-DevKitC-02. It worked without problems.