### PR TITLE
Bugfix spanish layout

### DIFF
--- a/include/clockWork.h
+++ b/include/clockWork.h
@@ -59,7 +59,7 @@ private:
     WordclockChanges changesInClockface();
     void calcClockface();
     void setClock();
-    void DetermineWhichItIsToShow(uint8_t offsetHour);
+    void DetermineWhichItIsToShow(uint8_t offsetHour, uint8_t min);
     void clearClockByProgInit();
 
 public:

--- a/include/clockWork.hpp
+++ b/include/clockWork.hpp
@@ -941,7 +941,7 @@ void ClockWork::DetermineWhichItIsToShow(uint8_t hour, uint8_t min) {
         }
     } else if (G.UhrtypeDef == Es10x11 && hour == 1 && min < 35) {
         usedUhrType->show(FrontWord::es_ist___plural___);
-    } else if (G.UhrtypeDef == Es10x11 && hour == 0 && min > 34 ){
+    } else if (G.UhrtypeDef == Es10x11 && hour == 0 && min > 34) {
         usedUhrType->show(FrontWord::es_ist___plural___);
     } else {
         usedUhrType->show(FrontWord::es_ist);

--- a/include/clockWork.hpp
+++ b/include/clockWork.hpp
@@ -917,15 +917,15 @@ void ClockWork::setClock() {
     setHour(_hour + offsetHour, fullHour);
 
     if (!G.languageVariant[NotShowItIs]) {
-        DetermineWhichItIsToShow(_hour + offsetHour);
+        DetermineWhichItIsToShow(_hour + offsetHour, _minute);
     }
 }
 
 //------------------------------------------------------------------------------
 
-void ClockWork::DetermineWhichItIsToShow(uint8_t hour) {
+void ClockWork::DetermineWhichItIsToShow(uint8_t hour, uint8_t min) {
+    hour %= 12;
     if (G.UhrtypeDef == Ru10x11) {
-        hour %= 12;
         switch (hour) {
         case 1:
             usedUhrType->show(FrontWord::es_ist__singular__);
@@ -940,6 +940,8 @@ void ClockWork::DetermineWhichItIsToShow(uint8_t hour) {
             break;
         }
     } else if (G.UhrtypeDef == Es10x11 && hour == 1) {
+        usedUhrType->show(FrontWord::es_ist___plural___);
+    } else if (G.UhrtypeDef == Es10x11 && hour == 0 && min > 34 ){
         usedUhrType->show(FrontWord::es_ist___plural___);
     } else {
         usedUhrType->show(FrontWord::es_ist);

--- a/include/clockWork.hpp
+++ b/include/clockWork.hpp
@@ -939,7 +939,7 @@ void ClockWork::DetermineWhichItIsToShow(uint8_t hour, uint8_t min) {
             usedUhrType->show(FrontWord::es_ist);
             break;
         }
-    } else if (G.UhrtypeDef == Es10x11 && hour == 1) {
+    } else if (G.UhrtypeDef == Es10x11 && hour == 1 && min < 35) {
         usedUhrType->show(FrontWord::es_ist___plural___);
     } else if (G.UhrtypeDef == Es10x11 && hour == 0 && min > 34 ){
         usedUhrType->show(FrontWord::es_ist___plural___);

--- a/include/clockWork.hpp
+++ b/include/clockWork.hpp
@@ -911,7 +911,6 @@ WordclockChanges ClockWork::changesInClockface() {
 
 void ClockWork::setClock() {
     uint8_t offsetHour = 0;
-    uint8_t offsetHour = 0;
     bool fullHour = 0;
 
     setMinute(_minute, offsetHour, fullHour);
@@ -940,7 +939,7 @@ void ClockWork::DetermineWhichItIsToShow(uint8_t hour, uint8_t min) {
             usedUhrType->show(FrontWord::es_ist);
             break;
         }
-    } else if (G.UhrtypeDef == Es10x11 && hour == 1 && min < 35) {
+    } else if (G.UhrtypeDef == Es10x11 && hour == 1) {
         usedUhrType->show(FrontWord::es_ist___plural___);
     } else if (G.UhrtypeDef == Es10x11 && hour == 0 && min > 34 ){
         usedUhrType->show(FrontWord::es_ist___plural___);

--- a/include/clockWork.hpp
+++ b/include/clockWork.hpp
@@ -911,6 +911,7 @@ WordclockChanges ClockWork::changesInClockface() {
 
 void ClockWork::setClock() {
     uint8_t offsetHour = 0;
+    uint8_t offsetHour = 0;
     bool fullHour = 0;
 
     setMinute(_minute, offsetHour, fullHour);
@@ -939,7 +940,7 @@ void ClockWork::DetermineWhichItIsToShow(uint8_t hour, uint8_t min) {
             usedUhrType->show(FrontWord::es_ist);
             break;
         }
-    } else if (G.UhrtypeDef == Es10x11 && hour == 1) {
+    } else if (G.UhrtypeDef == Es10x11 && hour == 1 && min < 35) {
         usedUhrType->show(FrontWord::es_ist___plural___);
     } else if (G.UhrtypeDef == Es10x11 && hour == 0 && min > 34 ){
         usedUhrType->show(FrontWord::es_ist___plural___);


### PR DESCRIPTION
Hello, 
I've implemented the clock in its Spanish version. There is a minor bug regarding the Spanish hours in the clockWork.hpp. 

- The clock was not displaying "Es la una " (es_ist___plural___) for hour = 1, because the hour modulo was calculated in the first if statement of  _DetermineWhichTimeItIs_. This was fixed by taking it out of the statement. 
- The clock should display "Es la una" for times  >12:34 and < 13:35.  Fixed by passing the minutes to _DetermineWhichTimeItIs_. 

The code was tested with a ESP8266. It worked without problems.