### PR TITLE
Passwörter vor Zugriff schützen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,3 +174,12 @@ typings/
 .vscode/extensions.json
 .vscode/launch.json
 .vscode/settings.json
+
+
+#########################
+# place for local stuff #
+#########################
+
+_[Mm]aterial/
+_[Ss]tuff/
+_[Ll]ocal/

--- a/include/EEPROMAnything.h
+++ b/include/EEPROMAnything.h
@@ -35,6 +35,7 @@ void write() {
 void read() {
     readAnything(0, G);
 
+#if GENERAL_VERBOSE
     Serial.printf("Version   : %s\n", VERSION);
     Serial.printf("Sernr     : %u\n", G.sernr);
     Serial.printf("Programm  : %u\n", G.prog);
@@ -62,7 +63,13 @@ void read() {
     Serial.printf("MQTT_State    : %u\n", G.mqtt.state);
     Serial.printf("MQTT_Server    : %s\n", G.mqtt.serverAdress);
     Serial.printf("MQTT_User    : %s\n", G.mqtt.user);
-    Serial.printf("MQTT_Pass    : %s\n", G.mqtt.password);
+
+    //don't expose password:
+    char passMasked[32];
+    strncpy(passMasked, G.mqtt.password, PAYLOAD_LENGTH);
+    strncpy(passMasked, "******************************", (strlen(passMasked) - 3));
+    Serial.printf("MQTT_Pass (masked): %s\n", passMasked);
+
     Serial.printf("MQTT_ClientId    : %s\n", G.mqtt.clientId);
     Serial.printf("MQTT_Topic    : %s\n", G.mqtt.topic);
     Serial.printf("MQTT_Port    : %u\n", G.mqtt.port);
@@ -90,6 +97,7 @@ void read() {
         Serial.printf("Birthday%1u: %02u.%02u.%04u\n", i, G.birthday[i].day,
                       G.birthday[i].month, G.birthday[i].year);
     }
+#endif
 
     delay(100);
 }

--- a/include/EEPROMAnything.h
+++ b/include/EEPROMAnything.h
@@ -64,10 +64,11 @@ void read() {
     Serial.printf("MQTT_Server    : %s\n", G.mqtt.serverAdress);
     Serial.printf("MQTT_User    : %s\n", G.mqtt.user);
 
-    //don't expose password:
+    // don't expose password:
     char passMasked[32];
     strncpy(passMasked, G.mqtt.password, PAYLOAD_LENGTH);
-    strncpy(passMasked, "******************************", (strlen(passMasked) - 3));
+    strncpy(passMasked, "******************************",
+            (strlen(passMasked) - 3));
     Serial.printf("MQTT_Pass (masked): %s\n", passMasked);
 
     Serial.printf("MQTT_ClientId    : %s\n", G.mqtt.clientId);

--- a/include/clockWork.hpp
+++ b/include/clockWork.hpp
@@ -1186,10 +1186,11 @@ void ClockWork::loop(struct tm &tm) {
         config["MQTT_Server"] = G.mqtt.serverAdress;
         config["MQTT_User"] = G.mqtt.user;
 
-        //don't expose password:
+        // don't expose password:
         char passMasked[32];
         strncpy(passMasked, G.mqtt.password, PAYLOAD_LENGTH);
-        strncpy(passMasked, "******************************", (strlen(passMasked) - 3));
+        strncpy(passMasked, "******************************", 
+                (strlen(passMasked) - 3));
         config["MQTT_Pass"] = passMasked;
 
         config["MQTT_ClientId"] = G.mqtt.clientId;

--- a/include/clockWork.hpp
+++ b/include/clockWork.hpp
@@ -1185,7 +1185,13 @@ void ClockWork::loop(struct tm &tm) {
         config["MQTT_Port"] = G.mqtt.port;
         config["MQTT_Server"] = G.mqtt.serverAdress;
         config["MQTT_User"] = G.mqtt.user;
-        config["MQTT_Pass"] = G.mqtt.password;
+
+        //don't expose password:
+        char passMasked[32];
+        strncpy(passMasked, G.mqtt.password, PAYLOAD_LENGTH);
+        strncpy(passMasked, "******************************", (strlen(passMasked) - 3));
+        config["MQTT_Pass"] = passMasked;
+
         config["MQTT_ClientId"] = G.mqtt.clientId;
         config["MQTT_Topic"] = G.mqtt.topic;
         serializeJson(config, str);

--- a/include/config.h
+++ b/include/config.h
@@ -229,11 +229,12 @@
 // Toggle Serial DEBUG Output
 //--------------------------------------------------------------------------
 /*
- * To delete or initialize the EEPROM, enter another serial number here.
+ * Enable or disable debug messages.
  *
  * Valid values [true, false]
  */
 #define GENERAL_VERBOSE true
+#define WIFI_VERBOSE false
 #define WEATHER_VERBOSE false
 
 //--------------------------------------------------------------------------

--- a/include/network.hpp
+++ b/include/network.hpp
@@ -4,7 +4,11 @@
 
 WiFiManager wifiManager(Serial);
 
-void Network::info() { WiFi.printDiag(Serial); }
+void Network::info() {
+#if WIFI_VERBOSE
+    WiFi.printDiag(Serial);
+#endif
+}
 
 int Network::getQuality() {
     int rssi = WiFi.RSSI();

--- a/include/webPageAdapter.h
+++ b/include/webPageAdapter.h
@@ -404,11 +404,13 @@ void webSocketEvent(uint8_t num, WStype_t type, uint8_t *payload,
             index_start += PAYLOAD_LENGTH;
             payloadTextHandling(payload, G.mqtt.user, index_start);
 
-            // check if submitted password has changed compared to masked password
+            // check if submitted password has changed compared to masked 
+            // password
             index_start += PAYLOAD_LENGTH;
             char passMasked[32];
             strncpy(passMasked, G.mqtt.password, PAYLOAD_LENGTH);
-            strncpy(passMasked, "******************************", (strlen(passMasked) - 3));
+            strncpy(passMasked, "******************************", 
+                    (strlen(passMasked) - 3));
             
             char passSumitted[32];
             payloadTextHandling(payload, passSumitted, index_start);

--- a/include/webPageAdapter.h
+++ b/include/webPageAdapter.h
@@ -403,8 +403,19 @@ void webSocketEvent(uint8_t num, WStype_t type, uint8_t *payload,
             payloadTextHandling(payload, G.mqtt.serverAdress, index_start);
             index_start += PAYLOAD_LENGTH;
             payloadTextHandling(payload, G.mqtt.user, index_start);
+
+            // check if submitted password has changed compared to masked password
             index_start += PAYLOAD_LENGTH;
-            payloadTextHandling(payload, G.mqtt.password, index_start);
+            char passMasked[32];
+            strncpy(passMasked, G.mqtt.password, PAYLOAD_LENGTH);
+            strncpy(passMasked, "******************************", (strlen(passMasked) - 3));
+            
+            char passSumitted[32];
+            payloadTextHandling(payload, passSumitted, index_start);
+            if (strcmp(passMasked, passSumitted) != 0) {
+                payloadTextHandling(payload, G.mqtt.password, index_start);
+            }
+
             index_start += PAYLOAD_LENGTH;
             payloadTextHandling(payload, G.mqtt.clientId, index_start);
             index_start += PAYLOAD_LENGTH;

--- a/src/Wortuhr.cpp
+++ b/src/Wortuhr.cpp
@@ -21,10 +21,9 @@
 #include <WiFiUdp.h>
 #include <Wire.h>
 
-#include "Uhr.h"
-
-#include "EEPROMAnything.h"
 #include "config.h"
+#include "Uhr.h"
+#include "EEPROMAnything.h"
 #include "uhrtype.gen.h"
 #include "webPageAdapter.h"
 
@@ -336,8 +335,10 @@ void setup() {
         led.setIcon(WLAN100);
     }
     network.setup(G.hostname);
+#if WIFI_VERBOSE
     int strength = network.getQuality();
     Serial.printf("Signal strength: %i\n", strength);
+#endif
     wifiStart();
     configTime(0, 0, G.timeserver);
     setenv("TZ", TZ_Europe_Berlin, true);

--- a/webpage/script.js
+++ b/webpage/script.js
@@ -335,12 +335,12 @@ function initWebsocket() {
 
 		if (data.command === "mqtt") {
 			$("#mqtt-port").set("value", data.MQTT_Port);
-			$("#mqtt-server").set("value", data.MQTT_Server);
+			$("#mqtt-server").set({ "value": data.MQTT_Server, "@maxlength": DATA_MQTT_RESPONSE_TEXT_LENGTH });
 			document.getElementById("mqtt-state").checked = data.MQTT_State;
-			$("#mqtt-user").set("value", data.MQTT_User);
-			$("#mqtt-pass").set("value", data.MQTT_Pass);
-			$("#mqtt-clientid").set("value", data.MQTT_ClientId);
-			$("#mqtt-topic").set("value", data.MQTT_Topic);
+			$("#mqtt-user").set({ "value": data.MQTT_User, "@maxlength": DATA_MQTT_RESPONSE_TEXT_LENGTH });
+			$("#mqtt-pass").set({ "value": data.MQTT_Pass, "@maxlength": DATA_MQTT_RESPONSE_TEXT_LENGTH });
+			$("#mqtt-clientid").set({ "value": data.MQTT_ClientId, "@maxlength": DATA_MQTT_RESPONSE_TEXT_LENGTH });
+			$("#mqtt-topic").set({ "value": data.MQTT_Topic, "@maxlength": DATA_MQTT_RESPONSE_TEXT_LENGTH });
 		}
 
 		if (data.command === "birthdays") {


### PR DESCRIPTION
Derzeit wird das MQTT-Passwort im Klartext in das Eingabefeld geschrieben und auch im Browser-Inspektor ausgegeben. Jeder mit Zugang zum WLAN kann somit das MQTT-Passwort auslesen. Darüber hinaus kann auch jeder OHNE Zugang zum WLAN das MQTT-Passwort ermitteln, wenn die Uhr sich gerade im AP-Modus (WifiManager) befindet. Der Angreifer gibt hierzu lediglich die Zugangsdaten seines eigenen (ggf. temporären) WLANs ein und kann anschließend über das Webinterface das Kennwort auslesen.

Wer physischen Zugang zur Uhr und die Möglichkeit zum Anschluss eines Kabels hat, der bekommt am Terminal Wifi-Diagnosedaten (inklusive WLAN-Passwort) als auch das MQTT-Passwort ausgegeben.

Mit diesem PR wird das MQTT-Passwort nur noch maskiert an Webpage und Terminal übergeben. Weiterhin werden Wifi-Diagnoseinformationen standardmäßig nicht mehr am Terminal ausgegeben (nur noch nach setzen der Konstante WIFI_VERBOSE auf true).