### PR TITLE
Passwortschutz captive portal

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -255,6 +255,25 @@
 #define WIFI_PASSWORD "Password"
 
 //--------------------------------------------------------------------------
+// Captive portal settings
+//--------------------------------------------------------------------------
+/*
+ * The captive portal is used to enter the WiFi credentials when 
+ * MANUAL_WIFI_SETTINGS is set to false. CP_SSID is used to set a custom
+ * SSID for the captive portal. CP_PROTECTED allows you to enable password 
+ * protection for the captive portal. In this case, remember to change 
+ * CP_PASSWORD to a secure password.
+ *
+ * Valid values CP_PROTECTED [true, false]
+ * Valid values CP_SSID [Alphanumeric Letters]
+ * Valid values CP_PASSWORD [Alphanumeric Letters]
+ *
+ */
+#define CP_PROTECTED false
+#define CP_SSID "Connect_to_Wordclock"
+#define CP_PASSWORD "CHANGE_THIS_PASSWORD"
+
+//--------------------------------------------------------------------------
 // Settings for Boot sequence
 //--------------------------------------------------------------------------
 /*

--- a/include/config.h
+++ b/include/config.h
@@ -258,10 +258,10 @@
 // Captive portal settings
 //--------------------------------------------------------------------------
 /*
- * The captive portal is used to enter the WiFi credentials when 
+ * The captive portal is used to enter the WiFi credentials when
  * MANUAL_WIFI_SETTINGS is set to false. CP_SSID is used to set a custom
- * SSID for the captive portal. CP_PROTECTED allows you to enable password 
- * protection for the captive portal. In this case, remember to change 
+ * SSID for the captive portal. CP_PROTECTED allows you to enable password
+ * protection for the captive portal. In this case, remember to change
  * CP_PASSWORD to a secure password.
  *
  * Valid values CP_PROTECTED [true, false]

--- a/include/network.h
+++ b/include/network.h
@@ -1,9 +1,6 @@
 #pragma once
 
 class Network {
-private:
-    const char *connectionSSID = "Connect_to_Wordclock";
-
 public:
     Network(/* args */) = default;
     ~Network() = default;

--- a/include/network.hpp
+++ b/include/network.hpp
@@ -33,7 +33,12 @@ void Network::setup(const char *hostname) {
 #if MANUAL_WIFI_SETTINGS
     wifiManager.preloadWiFi(WIFI_SSID, WIFI_PASSWORD);
 #endif
-    wifiManager.autoConnect(connectionSSID);
+    wifiManager.setConnectTimeout(20);
+#if CP_PROTECTED
+    wifiManager.autoConnect(CP_SSID, CP_PASSWORD);
+#else
+    wifiManager.autoConnect(CP_SSID);
+#endif
     // explicitly disable AP, esp defaults to STA+AP
     WiFi.enableAP(false);
     Network::info();

--- a/src/Wortuhr.cpp
+++ b/src/Wortuhr.cpp
@@ -22,7 +22,9 @@
 #include <Wire.h>
 
 #include "config.h"
+
 #include "Uhr.h"
+
 #include "EEPROMAnything.h"
 #include "uhrtype.gen.h"
 #include "webPageAdapter.h"

--- a/src/Wortuhr.cpp
+++ b/src/Wortuhr.cpp
@@ -168,13 +168,12 @@ void setup() {
     Serial.println(powerCycleCount);
     if (powerCycleCount == 3) {
         Serial.println("Enable captive portal");
-        #if CP_PROTECTED
-            wifiManager.startConfigPortal(CP_SSID, CP_PASSWORD);
-        #else
-            wifiManager.startConfigPortal(CP_SSID);
-        #endif
-    }
-    else if (powerCycleCount == 6) {
+#if CP_PROTECTED
+        wifiManager.startConfigPortal(CP_SSID, CP_PASSWORD);
+#else
+        wifiManager.startConfigPortal(CP_SSID);
+#endif
+    } else if (powerCycleCount == 6) {
         G.sernr++;
         Serial.println("Reset to initial values");
     }

--- a/src/Wortuhr.cpp
+++ b/src/Wortuhr.cpp
@@ -165,7 +165,15 @@ void setup() {
     incrementPowerCycleCount();
     Serial.print("Power cycle count: ");
     Serial.println(powerCycleCount);
-    if (powerCycleCount == 5) {
+    if (powerCycleCount == 3) {
+        Serial.println("Enable captive portal");
+        #if CP_PROTECTED
+            wifiManager.startConfigPortal(CP_SSID, CP_PASSWORD);
+        #else
+            wifiManager.startConfigPortal(CP_SSID);
+        #endif
+    }
+    else if (powerCycleCount == 6) {
         G.sernr++;
         Serial.println("Reset to initial values");
     }


### PR DESCRIPTION
Mit diesem PR kommt:
- Option einen Passwortschutz für das Captive Portal über die Konfiguration zu aktivieren
- PowerCycleReset modifiziert: nach 3 Zyklen wird das Captive Portal aktiviert, nach 6 Zyklen die Konfiguration zurückgesetzt.