### PR TITLE
Set default hue in config

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -176,11 +176,12 @@
  * at NeutralWhite.
  *
  * Valid values for DEFAULT_LEDTYPE [Brg, Grb, Rgb, Rbg, Gbr, Grbw]
- *
  * Valid values for WHITE_LEDTYPE [WarmWhite, NeutralWhite, ColdWhite]
+ * Valid values for DEFAULT_HUE [integer 0-255]
  */
 #define DEFAULT_LEDTYPE Brg
 #define WHITE_LEDTYPE WhiteType::NeutralWhite
+#define DEFAULT_HUE 120
 
 //--------------------------------------------------------------------------
 // Define Build Type

--- a/include/config.h
+++ b/include/config.h
@@ -173,7 +173,9 @@
  * with DEFAULT_LEDTYPE. If you have an RGBW LED strip, you can also use
  * WHITE_LEDTYPE to specify the type of white LED used (WarmWhite (3000K),
  * NeutralWhite (4300K) or ColdWhite (6500K)), in the case of RGB just leave it
- * at NeutralWhite.
+ * at NeutralWhite. With DEFAULT_HUE it is possible to define the hue value
+ * of the default color scheme. Use https://colorizer.org to get a hue value
+ * of your choice.
  *
  * Valid values for DEFAULT_LEDTYPE [Brg, Grb, Rgb, Rbg, Gbr, Grbw]
  * Valid values for WHITE_LEDTYPE [WarmWhite, NeutralWhite, ColdWhite]

--- a/src/Wortuhr.cpp
+++ b/src/Wortuhr.cpp
@@ -186,7 +186,7 @@ void setup() {
         for (uint8_t i = 0; i < 3; i++) {
             G.color[i] = {0, 0, 0};
         }
-        G.color[Foreground] = HsbColor(120 / 360.f, 1.f, 0.5f);
+        G.color[Foreground] = HsbColor(DEFAULT_HUE / 360.f, 1.f, 0.5f);
         G.effectBri = 2;
         G.effectSpeed = 10;
         G.client_nr = 0;


### PR DESCRIPTION
Derzeit ist die Standardfarbe (nach Neuprogrammierung oder Reset) grün. Je nach Gehäusefarbe kann ist das optisch unattraktiv bis problematisch sein (Stichwort Rot-Grün-Schwäche).

Mit diesem PR kann der Hue-Wert in der config definiert werden.