### PR TITLE
MQTT Senderate angepasst

### DIFF
--- a/include/Wortuhr.h
+++ b/include/Wortuhr.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <Arduino.h>
+
+void sendMQTTUpdate();

--- a/include/clockWork.hpp
+++ b/include/clockWork.hpp
@@ -1121,14 +1121,6 @@ void ClockWork::loop(struct tm &tm) {
             weather.loop();
         }
 
-        //------------------------------------------------
-        // MQTT
-        //------------------------------------------------
-
-        if (G.mqtt.state && WiFi.status() == WL_CONNECTED) {
-            mqtt.sendState();
-        }
-
         //--------------------------------------------
         // Auto Brightness Logic
         //--------------------------------------------
@@ -1160,6 +1152,12 @@ void ClockWork::loop(struct tm &tm) {
             colorChangedByWebsite = false;
             Serial.println("Saved Color");
         }
+
+        //------------------------------------------------
+        // MQTT
+        //------------------------------------------------
+
+        sendMQTTUpdate();
     }
 
     switch (G.conf) {

--- a/include/webPageAdapter.h
+++ b/include/webPageAdapter.h
@@ -602,4 +602,6 @@ void webSocketEvent(uint8_t num, WStype_t type, uint8_t *payload,
     default:
         break;
     }
+
+    sendMQTTUpdate();
 }

--- a/src/Wortuhr.cpp
+++ b/src/Wortuhr.cpp
@@ -1,4 +1,5 @@
 #include <Arduino.h>
+#include "Wortuhr.h"
 #include <ArduinoJson.h>
 #ifdef ESP8266
 #include <ESP8266HTTPUpdateServer.h>
@@ -134,6 +135,15 @@ void incrementPowerCycleCount() {
     powerCycleCount++;
     EEPROM.write(powerCycleCountAddr, powerCycleCount);
     EEPROM.commit();
+}
+
+//------------------------------------------------------------------------------
+
+void sendMQTTUpdate() {
+    // send status update via MQTT
+    if (G.mqtt.state && WiFi.status() == WL_CONNECTED) {
+        mqtt.sendState();
+    }
 }
 
 //------------------------------------------------------------------------------

--- a/src/Wortuhr.cpp
+++ b/src/Wortuhr.cpp
@@ -15,12 +15,12 @@
 #include <WiFi.h>
 #include <esp_sntp.h>
 #endif
+#include "Wortuhr.h"
 #include <NeoPixelBus.h>
 #include <RTClib.h>
 #include <WiFiClient.h>
 #include <WiFiUdp.h>
 #include <Wire.h>
-#include "Wortuhr.h"
 
 #include "Uhr.h"
 #include "config.h"

--- a/src/Wortuhr.cpp
+++ b/src/Wortuhr.cpp
@@ -1,5 +1,4 @@
 #include <Arduino.h>
-#include "Wortuhr.h"
 #include <ArduinoJson.h>
 #ifdef ESP8266
 #include <ESP8266HTTPUpdateServer.h>
@@ -21,6 +20,7 @@
 #include <WiFiClient.h>
 #include <WiFiUdp.h>
 #include <Wire.h>
+#include "Wortuhr.h"
 
 #include "Uhr.h"
 #include "config.h"
@@ -142,7 +142,7 @@ void incrementPowerCycleCount() {
 
 void sendMQTTUpdate() {
     // send status update via MQTT
-    if (G.mqtt.state && WiFi.status() == WL_CONNECTED) {
+    if ((G.mqtt.state) && (WiFi.status() == WL_CONNECTED)) {
         mqtt.sendState();
     }
 }


### PR DESCRIPTION
Derzeit wird im Sekundenintervall der aktuelle Status per MQTT gesendet. Das ist für 99,99% der Betriebszeit unnötig und verursacht auf dem Mikrocontroller viel Last und sorgt auch auf der empfangenden Seite für Stress.

Mit diesem PR wird auf einen minütlichen Intervall umgestellt und, im Falle von Änderungen im Webinterface, auf einen sofortigen Push.