### PR TITLE
Fix clock display in DE11x11.v3 layout by adding break statement to prevent 'uhr' and 'vor' from appearing together

### DIFF
--- a/include/Uhrtypes/DE11x11.v3.hpp
+++ b/include/Uhrtypes/DE11x11.v3.hpp
@@ -66,6 +66,8 @@ public:
         case FrontWord::vor:
         case FrontWord::v_vor:
             setFrontMatrixWord(3, 2, 4);
+            break;
+            
         case FrontWord::uhr:
             setFrontMatrixWord(9, 0, 2);
             break;


### PR DESCRIPTION
Added a break statement to the DE11x11.v3 layout. Without the statement, the clock always displays the words „uhr“ and „vor“ together (for instance, „Es ist zwanzig vor elf Uhr“). However, with the break statement, the word „UHR“ is only displayed when explicitly added (such as „Es ist elf Uhr“).